### PR TITLE
fix: add tests when no anonymous user

### DIFF
--- a/app/controllers/www/BlueprintEditController.php
+++ b/app/controllers/www/BlueprintEditController.php
@@ -665,8 +665,9 @@ class BlueprintEditController implements MiddlewareInterface
             /* @noinspection NullPointerExceptionInspection */
             Application::getDatabase()->startTransaction();
 
-            if ($params['ownership'] === 'give') {
-                $anonymousID = (int) Application::getConfig()->get('ANONYMOUS_ID');
+            $anonymousID = (int) Application::getConfig()->get('ANONYMOUS_ID');
+
+            if ($params['ownership'] === 'give' && $anonymousID > 0) {
                 BlueprintService::changeBlueprintAuthor($this->blueprintID, $anonymousID); // phpcs:ignore
                 UserService::updatePublicAndPrivateBlueprintCount($anonymousID, 1);
             } else {
@@ -755,6 +756,8 @@ class BlueprintEditController implements MiddlewareInterface
         $formDeleteBlueprint->setInputsErrors(Session::getFlash('form-delete_blueprint-errors'));
         $formDeleteBlueprint->setErrorMessage(Session::getFlash('error-form-delete_blueprint'));
         $this->data += ['form-delete_blueprint' => $formDeleteBlueprint];
+
+        $this->data += ['has_not_anonymous_user' => ((int) Application::getConfig()->get('ANONYMOUS_ID')) === 0];
 
         $this->setTemplateProperties([
             'slug'  => $this->data['blueprint']['slug'],

--- a/app/controllers/www/CronController.php
+++ b/app/controllers/www/CronController.php
@@ -281,6 +281,9 @@ class CronController
     protected function setSoftDeleteAnonymousPrivateBlueprints(): void
     {
         $anonymousID = (int) Application::getConfig()->get('ANONYMOUS_ID');
+        if ($anonymousID === 0) {
+            return;
+        }
 
         $forceRollback = false;
         $sqlSetSoftDeletedAnonymousPrivateBlueprints = <<<SQL

--- a/app/controllers/www/HomeController.php
+++ b/app/controllers/www/HomeController.php
@@ -182,6 +182,12 @@ class HomeController implements MiddlewareInterface
             Application::getDatabase()->startTransaction();
 
             $params['id_author'] = Session::get('userID') ?? (int) Application::getConfig()->get('ANONYMOUS_ID');
+            if ($params['id_author'] === 0) {
+                $errorMessage = 'Error, could not create blueprint, anonymous user not supported (#50)';
+
+                throw new \Exception($errorMessage);
+            }
+
             [$blueprint, $errorCode] = BlueprintService::createFromHome($params);
             if ($blueprint === null) {
                 $errorMessage = 'Error, could not create blueprint (' . $errorCode . ')';

--- a/app/controllers/www/ProfileEditController.php
+++ b/app/controllers/www/ProfileEditController.php
@@ -741,8 +741,10 @@ class ProfileEditController implements MiddlewareInterface
             /* @noinspection NullPointerExceptionInspection */
             Application::getDatabase()->startTransaction();
 
-            if ($params['blueprints_ownership'] === 'give') {
-                BlueprintService::changeAuthor($this->userID, (int) Application::getConfig()->get('ANONYMOUS_ID'));
+            $anonymousID = (int) Application::getConfig()->get('ANONYMOUS_ID');
+
+            if ($params['blueprints_ownership'] === 'give' && $anonymousID > 0) {
+                BlueprintService::changeAuthor($this->userID, $anonymousID);
             } else {
                 BlueprintService::softDeleteFromAuthor($this->userID);
             }

--- a/app/controllers/www/ProfileEditController.php
+++ b/app/controllers/www/ProfileEditController.php
@@ -830,6 +830,7 @@ class ProfileEditController implements MiddlewareInterface
         ];
 
         $this->data += ['links' => $links];
+        $this->data += ['has_not_anonymous_user' => ((int) Application::getConfig()->get('ANONYMOUS_ID')) === 0];
     }
 
     /**

--- a/app/views/www/pages/blueprint_edit.php
+++ b/app/views/www/pages/blueprint_edit.php
@@ -308,7 +308,7 @@ use Rancoud\Security\Security;
                             <label class="form__label" for="form-delete_blueprint-select-ownership" id="form-delete_blueprint-label-ownership">Blueprints ownership</label>
                             <div class="form__container form__container--select">
                                 <select aria-invalid="false" aria-labelledby="form-delete_blueprint-label-ownership<?php echo $formDeleteBlueprint->getClassError('ownership', ' form-delete_blueprint-label-ownership-error'); ?>" aria-required="true" class="form__input form__input--select<?php echo $formDeleteBlueprint->getClassError('ownership', ' form__input--error'); ?>" id="form-delete_blueprint-select-ownership" name="form-delete_blueprint-select-ownership">
-                                    <option value="give"<?php echo ($data['blueprint']['exposure'] === 'private') ? ' disabled="disabled"' : $formDeleteBlueprint->getSelectedValue('ownership', 'give'); ?>>Give my blueprint to anonymous user</option>
+                                    <option value="give"<?php echo ($data['blueprint']['exposure'] === 'private' || $data['has_not_anonymous_user']) ? ' disabled="disabled"' : $formDeleteBlueprint->getSelectedValue('ownership', 'give'); ?>>Give my blueprint to anonymous user</option>
                                     <option value="delete"<?php echo $formDeleteBlueprint->getSelectedValue('ownership', 'delete'); ?>>Delete my blueprint</option>
                                 </select>
                             </div>

--- a/app/views/www/pages/profile_edit.php
+++ b/app/views/www/pages/profile_edit.php
@@ -375,7 +375,7 @@ use Rancoud\Session\Session;
                             <label class="form__label" for="form-delete_profile-select-blueprints_ownership" id="form-delete_profile-label-blueprints_ownership">Blueprints ownership</label>
                             <div class="form__container form__container--select">
                                 <select aria-invalid="false" aria-labelledby="form-delete_profile-label-blueprints_ownership<?php echo $formDeleteProfile->getClassError('blueprints_ownership', ' form-delete_profile-label-blueprints_ownership-error'); ?>" aria-required="true" class="form__input form__input--select<?php echo $formDeleteProfile->getClassError('blueprints_ownership', ' form__input--error'); ?>" id="form-delete_profile-select-blueprints_ownership" name="form-delete_profile-select-blueprints_ownership">
-                                    <option value="give"<?php echo $formDeleteProfile->getSelectedValue('blueprints_ownership', 'give'); ?><?php echo ($formDeleteProfile->getInputValue('blueprints_ownership') === '') ? ' selected="selected"' : ''; ?>>Give my blueprints to anonymous user</option>
+                                    <option value="give"<?php echo ($data['has_not_anonymous_user']) ? ' disabled="disabled"' : $formDeleteProfile->getSelectedValue('blueprints_ownership', 'give'); ?><?php echo (!$data['has_not_anonymous_user'] && $formDeleteProfile->getInputValue('blueprints_ownership') === '') ? ' selected="selected"' : ''; ?>>Give my blueprints to anonymous user</option>
                                     <option value="delete"<?php echo $formDeleteProfile->getSelectedValue('blueprints_ownership', 'delete'); ?>>Delete my blueprints</option>
                                 </select>
                             </div>

--- a/tests/Common.php
+++ b/tests/Common.php
@@ -108,6 +108,7 @@ HTML;
      * @param array  $uploadedFiles
      * @param array  $additionalsFolders
      * @param array  $headers
+     * @param string $envFile
      *
      * @throws ApplicationException
      * @throws EnvironmentException
@@ -116,7 +117,7 @@ HTML;
      *
      * @return Response|null
      */
-    protected function getResponseFromApplication(string $method, string $url, array $params = [], array $session = [], array $cookies = [], array $queryParams = [], array $uploadedFiles = [], array $additionalsFolders = [], array $headers = []): ?Response
+    protected function getResponseFromApplication(string $method, string $url, array $params = [], array $session = [], array $cookies = [], array $queryParams = [], array $uploadedFiles = [], array $additionalsFolders = [], array $headers = [], string $envFile = 'tests.env'): ?Response
     {
         $ds = \DIRECTORY_SEPARATOR;
         $folders = [
@@ -128,7 +129,7 @@ HTML;
 
         $folders += $additionalsFolders;
 
-        $env = new Environment(__DIR__, 'tests.env');
+        $env = new Environment(__DIR__, $envFile);
 
         $_SERVER['HTTP_HOST'] = $env->get('HOST');
         $_SERVER['HTTPS'] = ($env->get('HTTPS') === true) ? 'on' : 'off';

--- a/tests/tests-no-anonymous-user.env
+++ b/tests/tests-no-anonymous-user.env
@@ -1,0 +1,67 @@
+# setup timezone, by default use timezone from php.ini (valid timezones are checked with DateTimeZone::listIdentifiers())
+TIMEZONE="UTC"
+
+# specific files to load for setting router, if null it will load all files in folder given in Application constructor
+ROUTES=null
+
+# for enabling DEBUG_* parameters
+DEBUG=true
+
+# enable error_reporting: show php errors
+DEBUG_PHP=true
+
+# keep PSR-7 request object
+DEBUG_REQUEST=false
+
+# keep PSR-7 response object
+DEBUG_RESPONSE=false
+
+# return saved queries
+DEBUG_DATABASE=false
+
+# return all values in Session object
+DEBUG_SESSION=false
+
+# return memory usage/limit/percentage
+DEBUG_MEMORY=false
+
+# return elapsed time of each Application->run()
+DEBUG_RUN_ELAPSED_TIMES=false
+
+# return all files included
+DEBUG_INCLUDED_FILES=false
+
+# database
+DATABASE_DRIVER=mysql
+DATABASE_HOST=127.0.0.1
+DATABASE_USER=blueprintue-self-hosted-edition
+DATABASE_PASSWORD=blueprintue-self-hosted-edition
+DATABASE_NAME=blueprintue-self-hosted-edition
+DATABASE_PERSISTENT_CONNECTION=true
+
+# session
+SESSION_DRIVER=database
+SESSION_ENCRYPT_KEY="1+XaQLUMfd/l6g1pdc/t+K1UiWJSuUY7k8GEjr+MLagmlgilqG8lcHrHc59ad9fo"
+SESSION_REMEMBER_NAME="remember_token"
+SESSION_REMEMBER_LIFETIME=2592000
+SESSION_REMEMBER_PATH="/"
+SESSION_REMEMBER_HTTPS=false
+SESSION_SAMESITE=Strict
+
+# host
+HOST=blueprintue.test
+HTTPS=true
+
+# site
+SITE_NAME=this_site_name
+SITE_BASE_TITLE="This is a base title"
+SITE_DESCRIPTION="This is a description"
+
+# anonymous
+ANONYMOUS_ID=
+
+# mail
+MAIL_FROM_ADDRESS=no-reply@blueprintue.test
+MAIL_FROM_NAME=blueprintUE_from_name
+MAIL_CONTACT_TO=contact@blueprintue.test
+MAIL_HEADER_LOGO_PATH="full-logo.png"

--- a/tests/www/Blueprint/Edit/BlueprintEditPOSTDeleteBlueprintTest.php
+++ b/tests/www/Blueprint/Edit/BlueprintEditPOSTDeleteBlueprintTest.php
@@ -510,9 +510,9 @@ class BlueprintEditPOSTDeleteBlueprintTest extends TestCase
             'remove' => []
         ];
 
-        $envFile = "tests.env";
+        $envFile = 'tests.env';
         if (!$hasAnonymousUser) {
-            $envFile = "tests-no-anonymous-user.env";
+            $envFile = 'tests-no-anonymous-user.env';
         }
 
         // generate csrf

--- a/tests/www/Blueprint/Edit/BlueprintEditPOSTDeleteBlueprintTest.php
+++ b/tests/www/Blueprint/Edit/BlueprintEditPOSTDeleteBlueprintTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace tests\www\Blueprint\Edit;
 
 use PHPUnit\Framework\TestCase;
+use Rancoud\Application\Application;
 use Rancoud\Application\ApplicationException;
 use Rancoud\Crypt\Crypt;
 use Rancoud\Database\DatabaseException;
@@ -87,6 +88,7 @@ class BlueprintEditPOSTDeleteBlueprintTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'delete OK - give blueprint - unlisted blueprint' => [
                 'sql_queries' => [
@@ -115,6 +117,7 @@ class BlueprintEditPOSTDeleteBlueprintTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'delete KO - give blueprint - private blueprint' => [
                 'sql_queries' => [
@@ -145,6 +148,7 @@ class BlueprintEditPOSTDeleteBlueprintTest extends TestCase
                 'fields_label_error'    => [
                     'ownership' => 'Ownership is invalid, you can&#039;t give blueprint when having private exposure'
                 ],
+                'has_anonymous_user'    => true
             ],
             'delete OK - delete blueprint - public blueprint' => [
                 'sql_queries' => [
@@ -173,6 +177,7 @@ class BlueprintEditPOSTDeleteBlueprintTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'delete OK - delete blueprint - unlisted blueprint' => [
                 'sql_queries' => [
@@ -201,6 +206,7 @@ class BlueprintEditPOSTDeleteBlueprintTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'delete OK - delete blueprint - private blueprint' => [
                 'sql_queries' => [
@@ -229,6 +235,36 @@ class BlueprintEditPOSTDeleteBlueprintTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
+            ],
+            'delete OK - no anonymous user - delete blueprint even if "give" sent - public blueprint' => [
+                'sql_queries' => [
+                    'REPLACE INTO users_infos (`id_user`, `count_private_blueprint`, `count_public_blueprint`) VALUES (189, 1, 1), (' . static::$anonymousID . ', 1, 1)',
+                    "REPLACE INTO blueprints (`id`, `id_author`, `slug`, `file_id`, `title`, `current_version`, `created_at`, `published_at`, `exposure`) VALUES (80, 189, 'slug_1', 'file_1', 'title_1', 1, utc_timestamp(), utc_timestamp(), 'public')",
+                    "REPLACE INTO blueprints_version (`id`, `id_blueprint`, `version`, `reason`, `created_at`, `published_at`) VALUES (900, 80, 1, 'Initial', utc_timestamp(), utc_timestamp())",
+                ],
+                'user_id'     => 189,
+                'params'      => [
+                    'form-delete_blueprint-hidden-csrf'      => 'csrf_is_replaced',
+                    'form-delete_blueprint-select-ownership' => 'give',
+                ],
+                'use_csrf_from_session' => true,
+                'has_redirection'       => true,
+                'is_form_success'       => true,
+                'flash_messages'        => [
+                    'success' => [
+                        'has'     => false,
+                        'message' => '<div class="block__info block__info--success" data-flash-success-for="form-delete_blueprint">'
+                    ],
+                    'error' => [
+                        'has'     => false,
+                        'message' => '<div class="block__info block__info--error" data-flash-error-for="form-delete_blueprint" role="alert">'
+                    ]
+                ],
+                'fields_has_error'      => [],
+                'fields_has_value'      => [],
+                'fields_label_error'    => [],
+                'has_anonymous_user'    => false
             ],
             'csrf incorrect' => [
                 'sql_queries' => [
@@ -257,6 +293,7 @@ class BlueprintEditPOSTDeleteBlueprintTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'missing fields - no csrf' => [
                 'sql_queries' => [
@@ -284,6 +321,7 @@ class BlueprintEditPOSTDeleteBlueprintTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'missing fields - no ownership' => [
                 'sql_queries' => [
@@ -311,6 +349,7 @@ class BlueprintEditPOSTDeleteBlueprintTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'empty fields - ownership' => [
                 'sql_queries' => [
@@ -341,6 +380,7 @@ class BlueprintEditPOSTDeleteBlueprintTest extends TestCase
                 'fields_label_error'    => [
                     'ownership' => 'Ownership is invalid'
                 ],
+                'has_anonymous_user'    => true
             ],
             'invalid fields - ownership invalid' => [
                 'sql_queries' => [
@@ -371,6 +411,7 @@ class BlueprintEditPOSTDeleteBlueprintTest extends TestCase
                 'fields_label_error'    => [
                     'ownership' => 'Ownership is invalid'
                 ],
+                'has_anonymous_user'    => true
             ],
             'invalid fields - ownership give is not possible with private exposure' => [
                 'sql_queries' => [
@@ -401,6 +442,7 @@ class BlueprintEditPOSTDeleteBlueprintTest extends TestCase
                 'fields_label_error'    => [
                     'ownership' => 'Ownership is invalid, you can&#039;t give blueprint when having private exposure'
                 ],
+                'has_anonymous_user'    => true
             ],
             'invalid encoding fields - select-ownership' => [
                 'sql_queries' => [
@@ -429,6 +471,7 @@ class BlueprintEditPOSTDeleteBlueprintTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
         ];
     }
@@ -446,13 +489,14 @@ class BlueprintEditPOSTDeleteBlueprintTest extends TestCase
      * @param array $fieldsHasError
      * @param array $fieldsHasValue
      * @param array $fieldsLabelError
+     * @param bool  $hasAnonymousUser
      *
      * @throws ApplicationException
      * @throws DatabaseException
      * @throws EnvironmentException
      * @throws RouterException
      */
-    public function testBlueprintEditPOSTDeleteBlueprint(array $sqlQueries, int $userID, array $params, bool $useCsrfFromSession, bool $hasRedirection, bool $isFormSuccess, array $flashMessages, array $fieldsHasError, array $fieldsHasValue, array $fieldsLabelError): void
+    public function testBlueprintEditPOSTDeleteBlueprint(array $sqlQueries, int $userID, array $params, bool $useCsrfFromSession, bool $hasRedirection, bool $isFormSuccess, array $flashMessages, array $fieldsHasError, array $fieldsHasValue, array $fieldsLabelError, bool $hasAnonymousUser): void
     {
         static::setDatabase();
 
@@ -466,8 +510,13 @@ class BlueprintEditPOSTDeleteBlueprintTest extends TestCase
             'remove' => []
         ];
 
+        $envFile = "tests.env";
+        if (!$hasAnonymousUser) {
+            $envFile = "tests-no-anonymous-user.env";
+        }
+
         // generate csrf
-        $this->getResponseFromApplication('GET', '/', [], $sessionValues);
+        $this->getResponseFromApplication('GET', '/', [], $sessionValues, [], [], [], [], [], $envFile);
 
         // put csrf
         if ($useCsrfFromSession) {
@@ -480,7 +529,7 @@ class BlueprintEditPOSTDeleteBlueprintTest extends TestCase
         $userInfosAnonymousBefore = static::$db->selectRow('SELECT * FROM users_infos WHERE id_user = ' . static::$anonymousID);
 
         // test response / redirection
-        $response = $this->getResponseFromApplication('POST', '/blueprint/slug_1/edit/', $params);
+        $response = $this->getResponseFromApplication('POST', '/blueprint/slug_1/edit/', $params, [], [], [], [], [], [], $envFile);
 
         if ($hasRedirection) {
             if ($isFormSuccess) {
@@ -490,7 +539,7 @@ class BlueprintEditPOSTDeleteBlueprintTest extends TestCase
             }
 
             $this->doTestHasResponseWithStatusCode($response, 301);
-            $response = $this->getResponseFromApplication('GET', $response->getHeaderLine('Location'));
+            $response = $this->getResponseFromApplication('GET', $response->getHeaderLine('Location'), [], [], [], [], [], [], [], $envFile);
             $this->doTestHasResponseWithStatusCode($response, 200);
         } else {
             $this->doTestHasResponseWithStatusCode($response, 200);
@@ -505,7 +554,7 @@ class BlueprintEditPOSTDeleteBlueprintTest extends TestCase
             static::assertNotSame($blueprintBefore, $blueprintAfter);
             static::assertNotSame($userInfosBefore, $userInfosAfter);
 
-            if ($params['form-delete_blueprint-select-ownership'] === 'give') {
+            if ($params['form-delete_blueprint-select-ownership'] === 'give' && ((int) Application::getConfig()->get('ANONYMOUS_ID') !== 0)) {
                 // blueprint
                 static::assertSame(static::$anonymousID, (int) $blueprintAfter['id_author']);
 

--- a/tests/www/Cron/CronSetSoftDeleteAnonymousPrivateBlueprintsTest.php
+++ b/tests/www/Cron/CronSetSoftDeleteAnonymousPrivateBlueprintsTest.php
@@ -58,4 +58,33 @@ class CronSetSoftDeleteAnonymousPrivateBlueprintsTest extends TestCase
         ];
         static::assertEqualsCanonicalizing($expectedBlueprintsSoftDeleted, $actualBlueprintsSoftDeleted);
     }
+
+    /**
+     * @throws ApplicationException
+     * @throws EnvironmentException
+     * @throws RouterException
+     * @throws \Rancoud\Database\DatabaseException
+     * @throws \Exception
+     */
+    public function testAbortCronSetSoftDeleteAnonymousPrivateBlueprintsGET(): void
+    {
+        $sql = <<<SQL
+            INSERT INTO blueprints (id, id_author, slug, file_id, title, current_version, created_at, published_at, exposure)
+            VALUES
+                (101, 2, 'slug_1', 'file_1', 'title_1', 1, utc_timestamp(), utc_timestamp(), 'public'),
+                (102, 2, 'slug_2', 'file_2', 'title_2', 1, utc_timestamp(), utc_timestamp(), 'unlisted'),
+                (103, 2, 'slug_3', 'file_3', 'title_3', 1, utc_timestamp(), utc_timestamp(), 'private'),
+                (104, 1, 'slug_4', 'file_4', 'title_4', 1, utc_timestamp(), utc_timestamp(), 'public'),
+                (105, 1, 'slug_5', 'file_5', 'title_5', 1, utc_timestamp(), utc_timestamp(), 'unlisted'),
+                (106, 1, 'slug_6', 'file_6', 'title_6', 1, utc_timestamp(), utc_timestamp(), 'private')
+        SQL;
+
+        static::$db->exec($sql);
+
+        $this->getResponseFromApplication('GET', '/cron/set_soft_delete_anonymous_private_blueprints/', [], [], [], [], [], [], [], 'tests-no-anonymous-user.env');
+
+        $actualBlueprintsSoftDeleted = static::$db->selectCol('SELECT id FROM blueprints WHERE deleted_at IS NOT NULL');
+        $expectedBlueprintsSoftDeleted = [];
+        static::assertEqualsCanonicalizing($expectedBlueprintsSoftDeleted, $actualBlueprintsSoftDeleted);
+    }
 }

--- a/tests/www/Cron/CronSetSoftDeleteAnonymousPrivateBlueprintsTest.php
+++ b/tests/www/Cron/CronSetSoftDeleteAnonymousPrivateBlueprintsTest.php
@@ -11,6 +11,7 @@ namespace tests\www\Cron;
 
 use PHPUnit\Framework\TestCase;
 use Rancoud\Application\ApplicationException;
+use Rancoud\Database\DatabaseException;
 use Rancoud\Environment\EnvironmentException;
 use Rancoud\Router\RouterException;
 use tests\Common;
@@ -26,6 +27,18 @@ class CronSetSoftDeleteAnonymousPrivateBlueprintsTest extends TestCase
     {
         static::setDatabaseEmptyStructure();
         static::addUsers();
+    }
+
+    /**
+     * @throws DatabaseException
+     */
+    protected function setUp(): void
+    {
+        $sql = <<<SQL
+            TRUNCATE TABLE blueprints
+        SQL;
+
+        static::$db->exec($sql);
     }
 
     /**

--- a/tests/www/Home/HomeTest.php
+++ b/tests/www/Home/HomeTest.php
@@ -87,6 +87,7 @@ class HomeTest extends TestCase
                 'fields_has_error'      => ['exposure', 'expiration', 'ue_version'],
                 'fields_has_value'      => ['title', 'exposure', 'expiration', 'ue_version', 'blueprint'],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'xss form - KO' => [
                 'user_id' => static::$anonymousID,
@@ -119,6 +120,7 @@ class HomeTest extends TestCase
                     'ue_version' => 'UE version is invalid',
                     'blueprint'  => 'Blueprint is invalid',
                 ],
+                'has_anonymous_user'    => true
             ],
             'anonymous - create blueprint OK - 1 hour' => [
                 'user_id' => static::$anonymousID,
@@ -146,6 +148,7 @@ class HomeTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'anonymous - create blueprint OK - 1 day' => [
                 'user_id' => static::$anonymousID,
@@ -173,6 +176,7 @@ class HomeTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'anonymous - create blueprint OK - 1 week' => [
                 'user_id' => static::$anonymousID,
@@ -200,6 +204,7 @@ class HomeTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'user - create blueprint OK' => [
                 'user_id' => static::$userID,
@@ -227,6 +232,7 @@ class HomeTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'csrf incorrect' => [
                 'user_id' => static::$anonymousID,
@@ -254,6 +260,7 @@ class HomeTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'missing fields - no fields' => [
                 'user_id'               => static::$anonymousID,
@@ -274,6 +281,7 @@ class HomeTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'missing fields - no csrf' => [
                 'user_id' => static::$anonymousID,
@@ -300,6 +308,7 @@ class HomeTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'missing fields - no title' => [
                 'user_id' => static::$anonymousID,
@@ -326,6 +335,7 @@ class HomeTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'missing fields - no exposure' => [
                 'user_id' => static::$anonymousID,
@@ -352,6 +362,7 @@ class HomeTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'missing fields - no ue_version' => [
                 'user_id' => static::$anonymousID,
@@ -378,6 +389,7 @@ class HomeTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'missing fields - no blueprint' => [
                 'user_id' => static::$anonymousID,
@@ -404,6 +416,7 @@ class HomeTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'empty fields - title empty' => [
                 'user_id' => static::$anonymousID,
@@ -433,6 +446,7 @@ class HomeTest extends TestCase
                 'fields_label_error'    => [
                     'title' => 'Title is required'
                 ],
+                'has_anonymous_user'    => true
             ],
             'empty fields - exposure empty' => [
                 'user_id' => static::$anonymousID,
@@ -462,6 +476,7 @@ class HomeTest extends TestCase
                 'fields_label_error'    => [
                     'exposure' => 'Exposure is required'
                 ],
+                'has_anonymous_user'    => true
             ],
             'empty fields - expiration empty' => [
                 'user_id' => static::$anonymousID,
@@ -491,6 +506,7 @@ class HomeTest extends TestCase
                 'fields_label_error'    => [
                     'expiration' => 'Expiration is required'
                 ],
+                'has_anonymous_user'    => true
             ],
             'empty fields - ue_version empty' => [
                 'user_id' => static::$anonymousID,
@@ -520,6 +536,7 @@ class HomeTest extends TestCase
                 'fields_label_error'    => [
                     'ue_version' => 'UE version is required'
                 ],
+                'has_anonymous_user'    => true
             ],
             'empty fields - blueprint empty' => [
                 'user_id' => static::$anonymousID,
@@ -549,6 +566,7 @@ class HomeTest extends TestCase
                 'fields_label_error'    => [
                     'blueprint' => 'Blueprint is required'
                 ],
+                'has_anonymous_user'    => true
             ],
             'invalid fields - exposure invalid' => [
                 'user_id' => static::$userID,
@@ -578,6 +596,7 @@ class HomeTest extends TestCase
                 'fields_label_error'    => [
                     'exposure' => 'Exposure is invalid'
                 ],
+                'has_anonymous_user'    => true
             ],
             'invalid fields - exposure private for anonymous' => [
                 'user_id' => static::$anonymousID,
@@ -607,6 +626,7 @@ class HomeTest extends TestCase
                 'fields_label_error'    => [
                     'exposure' => 'Private is for member only'
                 ],
+                'has_anonymous_user'    => true
             ],
             'invalid fields - expiration invalid' => [
                 'user_id' => static::$anonymousID,
@@ -636,6 +656,7 @@ class HomeTest extends TestCase
                 'fields_label_error'    => [
                     'expiration' => 'Expiration is invalid'
                 ],
+                'has_anonymous_user'    => true
             ],
             'invalid fields - ue_version invalid' => [
                 'user_id' => static::$anonymousID,
@@ -665,6 +686,7 @@ class HomeTest extends TestCase
                 'fields_label_error'    => [
                     'ue_version' => 'UE version is invalid'
                 ],
+                'has_anonymous_user'    => true
             ],
             'invalid fields - blueprint invalid' => [
                 'user_id' => static::$anonymousID,
@@ -694,6 +716,7 @@ class HomeTest extends TestCase
                 'fields_label_error'    => [
                     'blueprint' => 'Blueprint is invalid'
                 ],
+                'has_anonymous_user'    => true
             ],
             'throw exception in blueprint creation' => [
                 'user_id' => static::$anonymousID,
@@ -721,6 +744,35 @@ class HomeTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => ['title', 'exposure', 'expiration', 'ue_version', 'blueprint'],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
+            ],
+            'throw exception in blueprint creation when no anonymous user set' => [
+                'user_id' => 0,
+                'params'  => [
+                    'form-add_blueprint-hidden-csrf'        => 'csrf_is_replaced',
+                    'form-add_blueprint-input-title'        => 'title 1 hour',
+                    'form-add_blueprint-select-exposure'    => 'unlisted',
+                    'form-add_blueprint-select-expiration'  => 'never',
+                    'form-add_blueprint-select-ue_version'  => '4.14',
+                    'form-add_blueprint-textarea-blueprint' => 'Begin Object throw exception'
+                ],
+                'use_csrf_from_session' => true,
+                'has_redirection'       => true,
+                'is_form_success'       => false,
+                'flash_messages'        => [
+                    'success' => [
+                        'has'     => false,
+                        'message' => '<div class="block__info block__info--success" data-flash-success-for="form-add_blueprint">'
+                    ],
+                    'error' => [
+                        'has'     => true,
+                        'message' => '<div class="block__info block__info--error" data-flash-error-for="form-add_blueprint" role="alert">Error, could not create blueprint, anonymous user not supported (#50)</div>'
+                    ]
+                ],
+                'fields_has_error'      => [],
+                'fields_has_value'      => ['title', 'exposure', 'expiration', 'ue_version', 'blueprint'],
+                'fields_label_error'    => [],
+                'has_anonymous_user'    => false
             ],
             'invalid encoding fields - title' => [
                 'user_id' => static::$anonymousID,
@@ -748,6 +800,7 @@ class HomeTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'invalid encoding fields - exposure' => [
                 'user_id' => static::$anonymousID,
@@ -775,6 +828,7 @@ class HomeTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'invalid encoding fields - expiration' => [
                 'user_id' => static::$anonymousID,
@@ -802,6 +856,7 @@ class HomeTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'invalid encoding fields - ue_version' => [
                 'user_id' => static::$anonymousID,
@@ -829,6 +884,7 @@ class HomeTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'invalid encoding fields - blueprint' => [
                 'user_id' => static::$anonymousID,
@@ -856,6 +912,7 @@ class HomeTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
         ];
     }
@@ -872,11 +929,12 @@ class HomeTest extends TestCase
      * @param array $fieldsHasError
      * @param array $fieldsHasValue
      * @param array $fieldsLabelError
+     * @param bool  $hasAnonymousUser
      *
      * @throws DatabaseException
      * @throws \Exception
      */
-    public function testHomePOSTCreateBlueprint(int $userID, array $params, bool $useCsrfFromSession, bool $hasRedirection, bool $isFormSuccess, array $flashMessages, array $fieldsHasError, array $fieldsHasValue, array $fieldsLabelError): void
+    public function testHomePOSTCreateBlueprint(int $userID, array $params, bool $useCsrfFromSession, bool $hasRedirection, bool $isFormSuccess, array $flashMessages, array $fieldsHasError, array $fieldsHasValue, array $fieldsLabelError, bool $hasAnonymousUser): void
     {
         // set user in $_SESSION
         $session = ['remove' => ['anonymous_blueprints'], 'set' => []];
@@ -886,8 +944,13 @@ class HomeTest extends TestCase
             $session['remove'][] = 'userID';
         }
 
+        $envFile = 'tests.env';
+        if (!$hasAnonymousUser) {
+            $envFile = 'tests-no-anonymous-user.env';
+        }
+
         // generate csrf
-        $this->getResponseFromApplication('GET', '/', [], $session);
+        $this->getResponseFromApplication('GET', '/', [], $session, [], [], [], [], [], $envFile);
 
         // put csrf
         if ($useCsrfFromSession) {
@@ -903,7 +966,7 @@ class HomeTest extends TestCase
             static::$db->exec('ALTER TABLE blueprints CHANGE COLUMN `expiration` `expiration` DATETIME NOT NULL ;');
         }
 
-        $response = $this->getResponseFromApplication('POST', '/', $params);
+        $response = $this->getResponseFromApplication('POST', '/', $params, [], [], [], [], [], [], $envFile);
 
         if (isset($params['form-add_blueprint-textarea-blueprint']) && $params['form-add_blueprint-textarea-blueprint'] === 'Begin Object throw exception') {
             static::$db->exec('ALTER TABLE blueprints CHANGE COLUMN `expiration` `expiration` DATETIME NULL ;');

--- a/tests/www/Profile/Edit/ProfileEditPOSTDeleteProfileTest.php
+++ b/tests/www/Profile/Edit/ProfileEditPOSTDeleteProfileTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace tests\www\Profile\Edit;
 
 use PHPUnit\Framework\TestCase;
+use Rancoud\Application\Application;
 use Rancoud\Application\ApplicationException;
 use Rancoud\Crypt\Crypt;
 use Rancoud\Database\DatabaseException;
@@ -112,6 +113,7 @@ class ProfileEditPOSTDeleteProfileTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'delete OK - delete blueprints - keep comments' => [
                 'sql_queries' => [
@@ -143,6 +145,7 @@ class ProfileEditPOSTDeleteProfileTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'delete OK - give blueprints - anonymize comments' => [
                 'sql_queries' => [
@@ -174,6 +177,7 @@ class ProfileEditPOSTDeleteProfileTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'delete OK - delete blueprints - anonymize comments' => [
                 'sql_queries' => [
@@ -205,6 +209,7 @@ class ProfileEditPOSTDeleteProfileTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'delete OK - give blueprints - delete comments' => [
                 'sql_queries' => [
@@ -236,6 +241,7 @@ class ProfileEditPOSTDeleteProfileTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'delete OK - delete blueprints - delete comments' => [
                 'sql_queries' => [
@@ -267,6 +273,39 @@ class ProfileEditPOSTDeleteProfileTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
+            ],
+            'delete OK - no anonymous user - delete blueprints even if "give" sent - anonymize comments' => [
+                'sql_queries' => [
+                    "REPLACE INTO users (`id`, `username`, `password`, `slug`, `email`, `grade`, `created_at`, `avatar`) VALUES (189, 'user_189', null, 'user_189', 'user_189@example.com', 'member', UTC_TIMESTAMP(), null)",
+                    'REPLACE INTO users_infos (`id_user`) VALUES (189)',
+                    "REPLACE INTO users_api (`id_user`, `api_key`) VALUES (189, 'ABC')",
+                    "REPLACE INTO blueprints (`id`, `id_author`, `slug`, `file_id`, `title`, `current_version`, `created_at`, `published_at`, `exposure`) VALUES (80, 189, 'slug_1', 'file_1', 'title_1', 1, utc_timestamp(), utc_timestamp(), 'public')",
+                    "REPLACE INTO comments (`id`, `id_author`, `id_blueprint`, `content`, `created_at`) VALUES (50, 189, 80, 'my comment', utc_timestamp())",
+                ],
+                'user_id'     => 189,
+                'params'      => [
+                    'form-delete_profile-hidden-csrf'                 => 'csrf_is_replaced',
+                    'form-delete_profile-select-blueprints_ownership' => 'give',
+                    'form-delete_profile-select-comments_ownership'   => 'anonymize',
+                ],
+                'use_csrf_from_session' => true,
+                'has_redirection'       => true,
+                'is_form_success'       => true,
+                'flash_messages'        => [
+                    'success' => [
+                        'has'     => false,
+                        'message' => '<div class="block__info block__info--success" data-flash-success-for="form-delete_profile">'
+                    ],
+                    'error' => [
+                        'has'     => false,
+                        'message' => '<div class="block__info block__info--error" data-flash-error-for="form-delete_profile" role="alert">'
+                    ]
+                ],
+                'fields_has_error'      => [],
+                'fields_has_value'      => [],
+                'fields_label_error'    => [],
+                'has_anonymous_user'    => false
             ],
             'csrf incorrect' => [
                 'sql_queries' => [
@@ -298,6 +337,7 @@ class ProfileEditPOSTDeleteProfileTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'missing fields - no csrf' => [
                 'sql_queries' => [
@@ -328,6 +368,7 @@ class ProfileEditPOSTDeleteProfileTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'missing fields - no blueprints_ownership' => [
                 'sql_queries' => [
@@ -358,6 +399,7 @@ class ProfileEditPOSTDeleteProfileTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'missing fields - no comments_ownership' => [
                 'sql_queries' => [
@@ -388,6 +430,7 @@ class ProfileEditPOSTDeleteProfileTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'empty fields - blueprints_ownership' => [
                 'sql_queries' => [
@@ -421,6 +464,7 @@ class ProfileEditPOSTDeleteProfileTest extends TestCase
                 'fields_label_error'    => [
                     'blueprints_ownership' => 'Blueprints Ownership is invalid'
                 ],
+                'has_anonymous_user'    => true
             ],
             'empty fields - comments_ownership' => [
                 'sql_queries' => [
@@ -454,6 +498,7 @@ class ProfileEditPOSTDeleteProfileTest extends TestCase
                 'fields_label_error'    => [
                     'comments_ownership' => 'Comments Ownership is invalid'
                 ],
+                'has_anonymous_user'    => true
             ],
             'invalid fields - blueprints_ownership invalid (keep-comments)' => [
                 'sql_queries' => [
@@ -487,6 +532,7 @@ class ProfileEditPOSTDeleteProfileTest extends TestCase
                 'fields_label_error'    => [
                     'blueprints_ownership' => 'Blueprints Ownership is invalid'
                 ],
+                'has_anonymous_user'    => true
             ],
             'invalid fields - blueprints_ownership invalid (anonymize-comments)' => [
                 'sql_queries' => [
@@ -520,6 +566,7 @@ class ProfileEditPOSTDeleteProfileTest extends TestCase
                 'fields_label_error'    => [
                     'blueprints_ownership' => 'Blueprints Ownership is invalid'
                 ],
+                'has_anonymous_user'    => true
             ],
             'invalid fields - blueprints_ownership invalid (delete-comments)' => [
                 'sql_queries' => [
@@ -553,6 +600,7 @@ class ProfileEditPOSTDeleteProfileTest extends TestCase
                 'fields_label_error'    => [
                     'blueprints_ownership' => 'Blueprints Ownership is invalid'
                 ],
+                'has_anonymous_user'    => true
             ],
             'invalid fields - comments_ownership invalid (give-blueprints)' => [
                 'sql_queries' => [
@@ -586,6 +634,7 @@ class ProfileEditPOSTDeleteProfileTest extends TestCase
                 'fields_label_error'    => [
                     'comments_ownership' => 'Comments Ownership is invalid'
                 ],
+                'has_anonymous_user'    => true
             ],
             'invalid fields - comments_ownership invalid (delete-blueprints)' => [
                 'sql_queries' => [
@@ -619,6 +668,7 @@ class ProfileEditPOSTDeleteProfileTest extends TestCase
                 'fields_label_error'    => [
                     'comments_ownership' => 'Comments Ownership is invalid'
                 ],
+                'has_anonymous_user'    => true
             ],
             'invalid encoding fields - blueprints_ownership' => [
                 'sql_queries' => [
@@ -650,6 +700,7 @@ class ProfileEditPOSTDeleteProfileTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
             'invalid encoding fields - comments_ownership' => [
                 'sql_queries' => [
@@ -681,6 +732,7 @@ class ProfileEditPOSTDeleteProfileTest extends TestCase
                 'fields_has_error'      => [],
                 'fields_has_value'      => [],
                 'fields_label_error'    => [],
+                'has_anonymous_user'    => true
             ],
         ];
     }
@@ -698,13 +750,14 @@ class ProfileEditPOSTDeleteProfileTest extends TestCase
      * @param array $fieldsHasError
      * @param array $fieldsHasValue
      * @param array $fieldsLabelError
+     * @param bool  $hasAnonymousUser
      *
      * @throws ApplicationException
      * @throws DatabaseException
      * @throws EnvironmentException
      * @throws RouterException
      */
-    public function testProfileEditPOSTDeleteProfile(array $sqlQueries, int $userID, array $params, bool $useCsrfFromSession, bool $hasRedirection, bool $isFormSuccess, array $flashMessages, array $fieldsHasError, array $fieldsHasValue, array $fieldsLabelError): void
+    public function testProfileEditPOSTDeleteProfile(array $sqlQueries, int $userID, array $params, bool $useCsrfFromSession, bool $hasRedirection, bool $isFormSuccess, array $flashMessages, array $fieldsHasError, array $fieldsHasValue, array $fieldsLabelError, bool $hasAnonymousUser): void
     {
         static::setDatabase();
 
@@ -718,8 +771,13 @@ class ProfileEditPOSTDeleteProfileTest extends TestCase
             'remove' => []
         ];
 
+        $envFile = 'tests.env';
+        if (!$hasAnonymousUser) {
+            $envFile = 'tests-no-anonymous-user.env';
+        }
+
         // generate csrf
-        $this->getResponseFromApplication('GET', '/', [], $sessionValues);
+        $this->getResponseFromApplication('GET', '/', [], $sessionValues, [], [], [], [], [], $envFile);
 
         // put csrf
         if ($useCsrfFromSession) {
@@ -734,7 +792,7 @@ class ProfileEditPOSTDeleteProfileTest extends TestCase
         $commentsBefore = static::$db->selectRow('SELECT * FROM comments WHERE id_author = ' . $userID);
 
         // test response / redirection
-        $response = $this->getResponseFromApplication('POST', '/profile/user_' . $userID . '/edit/', $params);
+        $response = $this->getResponseFromApplication('POST', '/profile/user_' . $userID . '/edit/', $params, [], [], [], [], [], [], $envFile);
 
         if ($hasRedirection) {
             if ($isFormSuccess) {
@@ -744,7 +802,7 @@ class ProfileEditPOSTDeleteProfileTest extends TestCase
             }
 
             $this->doTestHasResponseWithStatusCode($response, 301);
-            $response = $this->getResponseFromApplication('GET', $response->getHeaderLine('Location'));
+            $response = $this->getResponseFromApplication('GET', $response->getHeaderLine('Location'), [], [], [], [], [], [], [], $envFile);
             $this->doTestHasResponseWithStatusCode($response, 200);
         } else {
             $this->doTestHasResponseWithStatusCode($response, 200);
@@ -764,7 +822,7 @@ class ProfileEditPOSTDeleteProfileTest extends TestCase
             static::assertNotSame($blueprintsBefore, $blueprintsAfter);
             static::assertNotSame($commentsBefore, $commentsAfter);
 
-            if ($params['form-delete_profile-select-blueprints_ownership'] === 'give') {
+            if ($params['form-delete_profile-select-blueprints_ownership'] === 'give' && ((int) Application::getConfig()->get('ANONYMOUS_ID') !== 0)) {
                 $blueprint = static::$db->selectRow('SELECT * FROM blueprints WHERE id = ' . $blueprintsBefore['id']);
                 static::assertSame(static::$anonymousID, (int) $blueprint['id_author']);
             } elseif ($params['form-delete_profile-select-blueprints_ownership'] === 'delete') {


### PR DESCRIPTION
If there is no `ANONYMOUS_ID` set in the `.env` file then we need to add some checks to avoid errors and `user_id=0`.
* replace `give` with `delete` when delete blueprint and no anonymous user
* replace `give` with `delete` when delete profile and no anonymous user
* do not create anonymous blueprint on home when no anonymous user
* do not run cron `set_soft_delete_anonymous_private_blueprints` when no anonymous user