### PR TITLE
chore: update rancoud dependencies

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -139,16 +139,16 @@
         },
         {
             "name": "rancoud/application",
-            "version": "5.2.5",
+            "version": "5.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Application.git",
-                "reference": "f9b3835a2aa8d65757cc081ce8183863811a4cfe"
+                "reference": "15bd406130018a8b97154f8a3a223ef42aa57dbe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Application/zipball/f9b3835a2aa8d65757cc081ce8183863811a4cfe",
-                "reference": "f9b3835a2aa8d65757cc081ce8183863811a4cfe",
+                "url": "https://api.github.com/repos/rancoud/Application/zipball/15bd406130018a8b97154f8a3a223ef42aa57dbe",
+                "reference": "15bd406130018a8b97154f8a3a223ef42aa57dbe",
                 "shasum": ""
             },
             "require": {
@@ -182,22 +182,22 @@
             "description": "Application package",
             "support": {
                 "issues": "https://github.com/rancoud/Application/issues",
-                "source": "https://github.com/rancoud/Application/tree/5.2.5"
+                "source": "https://github.com/rancoud/Application/tree/5.2.6"
             },
-            "time": "2024-01-20T18:41:06+00:00"
+            "time": "2024-03-03T21:16:52+00:00"
         },
         {
             "name": "rancoud/crypt",
-            "version": "3.2.5",
+            "version": "3.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Crypt.git",
-                "reference": "617b1c131197fd415f450724881c7a114a2ab848"
+                "reference": "d1658e20182c1f260a6b422ab5199fbb9f8e0048"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Crypt/zipball/617b1c131197fd415f450724881c7a114a2ab848",
-                "reference": "617b1c131197fd415f450724881c7a114a2ab848",
+                "url": "https://api.github.com/repos/rancoud/Crypt/zipball/d1658e20182c1f260a6b422ab5199fbb9f8e0048",
+                "reference": "d1658e20182c1f260a6b422ab5199fbb9f8e0048",
                 "shasum": ""
             },
             "require": {
@@ -228,22 +228,22 @@
             "description": "Crypt package",
             "support": {
                 "issues": "https://github.com/rancoud/Crypt/issues",
-                "source": "https://github.com/rancoud/Crypt/tree/3.2.5"
+                "source": "https://github.com/rancoud/Crypt/tree/3.2.7"
             },
-            "time": "2024-01-20T16:13:48+00:00"
+            "time": "2024-03-03T17:48:30+00:00"
         },
         {
             "name": "rancoud/database",
-            "version": "6.0.8",
+            "version": "6.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Database.git",
-                "reference": "716236f7e728cebecb2a10b17fe99d975ac842f7"
+                "reference": "b8eab4676ccfce8cd483cfcc6b0487d57f18aae7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Database/zipball/716236f7e728cebecb2a10b17fe99d975ac842f7",
-                "reference": "716236f7e728cebecb2a10b17fe99d975ac842f7",
+                "url": "https://api.github.com/repos/rancoud/Database/zipball/b8eab4676ccfce8cd483cfcc6b0487d57f18aae7",
+                "reference": "b8eab4676ccfce8cd483cfcc6b0487d57f18aae7",
                 "shasum": ""
             },
             "require": {
@@ -279,22 +279,22 @@
             "description": "Database package",
             "support": {
                 "issues": "https://github.com/rancoud/Database/issues",
-                "source": "https://github.com/rancoud/Database/tree/6.0.8"
+                "source": "https://github.com/rancoud/Database/tree/6.0.9"
             },
-            "time": "2024-01-20T17:26:47+00:00"
+            "time": "2024-03-03T19:21:31+00:00"
         },
         {
             "name": "rancoud/environment",
-            "version": "2.1.9",
+            "version": "2.1.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Environment.git",
-                "reference": "44b75c131de89f77168b10bac86acebb9697023e"
+                "reference": "81d98ace065a952db6c79bdb05d0c81ddd941212"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Environment/zipball/44b75c131de89f77168b10bac86acebb9697023e",
-                "reference": "44b75c131de89f77168b10bac86acebb9697023e",
+                "url": "https://api.github.com/repos/rancoud/Environment/zipball/81d98ace065a952db6c79bdb05d0c81ddd941212",
+                "reference": "81d98ace065a952db6c79bdb05d0c81ddd941212",
                 "shasum": ""
             },
             "require": {
@@ -325,22 +325,22 @@
             "description": "Environment package",
             "support": {
                 "issues": "https://github.com/rancoud/Environment/issues",
-                "source": "https://github.com/rancoud/Environment/tree/2.1.9"
+                "source": "https://github.com/rancoud/Environment/tree/2.1.10"
             },
-            "time": "2024-01-20T17:59:02+00:00"
+            "time": "2024-03-03T20:27:54+00:00"
         },
         {
             "name": "rancoud/http",
-            "version": "3.2.1",
+            "version": "3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Http.git",
-                "reference": "634b89e83d0e8af1b9a1661cc946e62a03efa3ba"
+                "reference": "ea5e0882533da98fb051fa187fedaa396f31da75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Http/zipball/634b89e83d0e8af1b9a1661cc946e62a03efa3ba",
-                "reference": "634b89e83d0e8af1b9a1661cc946e62a03efa3ba",
+                "url": "https://api.github.com/repos/rancoud/Http/zipball/ea5e0882533da98fb051fa187fedaa396f31da75",
+                "reference": "ea5e0882533da98fb051fa187fedaa396f31da75",
                 "shasum": ""
             },
             "require": {
@@ -378,22 +378,22 @@
             "description": "Http package",
             "support": {
                 "issues": "https://github.com/rancoud/Http/issues",
-                "source": "https://github.com/rancoud/Http/tree/3.2.1"
+                "source": "https://github.com/rancoud/Http/tree/3.2.2"
             },
-            "time": "2024-01-20T18:05:12+00:00"
+            "time": "2024-03-03T20:42:02+00:00"
         },
         {
             "name": "rancoud/model",
-            "version": "4.1.4",
+            "version": "4.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Model.git",
-                "reference": "04804bf78ae81a77bb8f69115f93852296e441a7"
+                "reference": "3033a55789fa96c58c69a6e9628eb68236846c69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Model/zipball/04804bf78ae81a77bb8f69115f93852296e441a7",
-                "reference": "04804bf78ae81a77bb8f69115f93852296e441a7",
+                "url": "https://api.github.com/repos/rancoud/Model/zipball/3033a55789fa96c58c69a6e9628eb68236846c69",
+                "reference": "3033a55789fa96c58c69a6e9628eb68236846c69",
                 "shasum": ""
             },
             "require": {
@@ -432,22 +432,22 @@
             "description": "Model package",
             "support": {
                 "issues": "https://github.com/rancoud/Model/issues",
-                "source": "https://github.com/rancoud/Model/tree/4.1.4"
+                "source": "https://github.com/rancoud/Model/tree/4.1.5"
             },
-            "time": "2024-01-20T17:38:15+00:00"
+            "time": "2024-03-03T19:39:40+00:00"
         },
         {
             "name": "rancoud/pagination",
-            "version": "3.1.5",
+            "version": "3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Pagination.git",
-                "reference": "20f1bdb7337fe73df6abe22b0917149c2b539eee"
+                "reference": "b7415b334350e133e25e24671a4aac905d2a42c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Pagination/zipball/20f1bdb7337fe73df6abe22b0917149c2b539eee",
-                "reference": "20f1bdb7337fe73df6abe22b0917149c2b539eee",
+                "url": "https://api.github.com/repos/rancoud/Pagination/zipball/b7415b334350e133e25e24671a4aac905d2a42c0",
+                "reference": "b7415b334350e133e25e24671a4aac905d2a42c0",
                 "shasum": ""
             },
             "require": {
@@ -479,22 +479,22 @@
             "description": "Pagination package",
             "support": {
                 "issues": "https://github.com/rancoud/Pagination/issues",
-                "source": "https://github.com/rancoud/Pagination/tree/3.1.5"
+                "source": "https://github.com/rancoud/Pagination/tree/3.1.6"
             },
-            "time": "2024-01-20T17:20:15+00:00"
+            "time": "2024-03-03T19:03:39+00:00"
         },
         {
             "name": "rancoud/router",
-            "version": "3.1.3",
+            "version": "3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Router.git",
-                "reference": "f2e4d52b8ae7a5f839ae4dd8e2dfabd05b23e406"
+                "reference": "b94332349dc19af624bdf78e18af1a0caa73c257"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Router/zipball/f2e4d52b8ae7a5f839ae4dd8e2dfabd05b23e406",
-                "reference": "f2e4d52b8ae7a5f839ae4dd8e2dfabd05b23e406",
+                "url": "https://api.github.com/repos/rancoud/Router/zipball/b94332349dc19af624bdf78e18af1a0caa73c257",
+                "reference": "b94332349dc19af624bdf78e18af1a0caa73c257",
                 "shasum": ""
             },
             "require": {
@@ -525,22 +525,22 @@
             "description": "Router package",
             "support": {
                 "issues": "https://github.com/rancoud/Router/issues",
-                "source": "https://github.com/rancoud/Router/tree/3.1.3"
+                "source": "https://github.com/rancoud/Router/tree/3.1.4"
             },
-            "time": "2024-01-20T18:18:50+00:00"
+            "time": "2024-03-03T21:00:23+00:00"
         },
         {
             "name": "rancoud/security",
-            "version": "3.0.9",
+            "version": "3.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Security.git",
-                "reference": "a2d66b39f66295922b9b45d714f98662fd7ece9d"
+                "reference": "855e55e3fd194207690a102487807d280d63f5cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Security/zipball/a2d66b39f66295922b9b45d714f98662fd7ece9d",
-                "reference": "a2d66b39f66295922b9b45d714f98662fd7ece9d",
+                "url": "https://api.github.com/repos/rancoud/Security/zipball/855e55e3fd194207690a102487807d280d63f5cc",
+                "reference": "855e55e3fd194207690a102487807d280d63f5cc",
                 "shasum": ""
             },
             "require": {
@@ -571,22 +571,22 @@
             "description": "Security package",
             "support": {
                 "issues": "https://github.com/rancoud/Security/issues",
-                "source": "https://github.com/rancoud/Security/tree/3.0.9"
+                "source": "https://github.com/rancoud/Security/tree/3.0.11"
             },
-            "time": "2024-01-20T16:57:21+00:00"
+            "time": "2024-03-03T18:41:11+00:00"
         },
         {
             "name": "rancoud/session",
-            "version": "5.0.5",
+            "version": "5.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Session.git",
-                "reference": "1a6218aff0c13c2cc38b1bc5f43f5a9790946259"
+                "reference": "38758dc43e8fcf06a17b1e337bbf9969e3e04183"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Session/zipball/1a6218aff0c13c2cc38b1bc5f43f5a9790946259",
-                "reference": "1a6218aff0c13c2cc38b1bc5f43f5a9790946259",
+                "url": "https://api.github.com/repos/rancoud/Session/zipball/38758dc43e8fcf06a17b1e337bbf9969e3e04183",
+                "reference": "38758dc43e8fcf06a17b1e337bbf9969e3e04183",
                 "shasum": ""
             },
             "require": {
@@ -621,9 +621,9 @@
             "description": "Session package",
             "support": {
                 "issues": "https://github.com/rancoud/Session/issues",
-                "source": "https://github.com/rancoud/Session/tree/5.0.5"
+                "source": "https://github.com/rancoud/Session/tree/5.0.6"
             },
-            "time": "2024-01-20T17:53:24+00:00"
+            "time": "2024-03-03T20:19:48+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
# Description
* Upgrading `rancoud/application` from `5.2.5` to `5.2.6`
* Upgrading `rancoud/crypt` from `3.2.5` to `3.2.7`
* Upgrading `rancoud/database` from `6.0.8` to `6.0.9`
* Upgrading `rancoud/environment` from `2.1.9` to `2.1.10`
* Upgrading `rancoud/http` from `3.2.1` to `3.2.2`
* Upgrading `rancoud/model` from `4.1.4` to `4.1.5`
* Upgrading `rancoud/pagination` from `3.1.5` to `3.1.6`
* Upgrading `rancoud/router` from `3.1.3` to `3.1.4`
* Upgrading `rancoud/security` from `3.0.9` to `3.0.11`
* Upgrading `rancoud/session` from `5.0.5` to `5.0.6`
