### PR TITLE
feat: add blueprint expander

### DIFF
--- a/app/views/www/pages/blueprint.php
+++ b/app/views/www/pages/blueprint.php
@@ -22,6 +22,7 @@ use Rancoud\Security\Security;
     <main class="main">
         <div class="block__container block__container--first block__container--black block__container--no-padding">
             <div class="block__element--iframe" id="blueprint-render-playground"></div>
+            <div class="expander-bar-handler" id="handler"></div>
         </div>
         <div class="block__container">
             <?php
@@ -393,6 +394,12 @@ use Rancoud\Security\Security;
             document.getElementById('code_to_copy').value,
             document.getElementById('blueprint-render-playground'),
             {height:"643px"}
-        ).start();
+        ).start(function(){
+            new window.blueprintUE.www.Expander(
+                document.getElementById("blueprint-render-playground"),
+                document.getElementById("handler"),
+                643
+            ).start();
+        });
     </script>
 </body>

--- a/www/site.css
+++ b/www/site.css
@@ -1988,6 +1988,21 @@ main {
     min-width: 150px;
     padding: 10px;
 }
+.expander-bar-handler{
+    cursor: row-resize;
+    height:10px;
+    user-select: none;
+    width:100%;
+}
+.expander-bar-handler:after{
+    content: "• • •";
+    align-items: center;
+    display: flex;
+    font-weight: 700;
+    font-size: 20px;
+    height: 10px;
+    justify-content: center;
+}
 html[data-theme="dark"] body {
     color: #d0d0d0;
 }


### PR DESCRIPTION
# Description
When using a screen resolution higher than 1080p, you may end up with a blueprint that doesn't occupy the full height of the screen.
To adapt to all resolutions, a handlebar below the blueprint lets you enlarge it.
The new size being stored in browser local storage and having a minimum size of 643 px.

https://github.com/blueprintue/blueprintue-self-hosted-edition/assets/1884186/1f63c806-e6e4-4df3-9812-5c8ff4333e57