### PR TITLE
chore: bump rancoud dependencies

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -485,25 +485,25 @@
         },
         {
             "name": "rancoud/router",
-            "version": "3.1.4",
+            "version": "3.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Router.git",
-                "reference": "b94332349dc19af624bdf78e18af1a0caa73c257"
+                "reference": "6322abc3dc1781cac1add3c0fc3798926a6c0e54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Router/zipball/b94332349dc19af624bdf78e18af1a0caa73c257",
-                "reference": "b94332349dc19af624bdf78e18af1a0caa73c257",
+                "url": "https://api.github.com/repos/rancoud/Router/zipball/6322abc3dc1781cac1add3c0fc3798926a6c0e54",
+                "reference": "6322abc3dc1781cac1add3c0fc3798926a6c0e54",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4.0",
-                "rancoud/http": "^3.0"
+                "rancoud/http": "^3.2"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.16 || ^3.0",
-                "phpunit/phpunit": "^9.1",
+                "phpunit/phpunit": "^9.1 || ^10.0 || ^11.0",
                 "squizlabs/php_codesniffer": "^3.5"
             },
             "type": "library",
@@ -525,9 +525,9 @@
             "description": "Router package",
             "support": {
                 "issues": "https://github.com/rancoud/Router/issues",
-                "source": "https://github.com/rancoud/Router/tree/3.1.4"
+                "source": "https://github.com/rancoud/Router/tree/3.1.5"
             },
-            "time": "2024-03-03T21:00:23+00:00"
+            "time": "2024-05-23T21:14:12+00:00"
         },
         {
             "name": "rancoud/security",

--- a/composer.lock
+++ b/composer.lock
@@ -384,16 +384,16 @@
         },
         {
             "name": "rancoud/model",
-            "version": "4.1.5",
+            "version": "4.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Model.git",
-                "reference": "3033a55789fa96c58c69a6e9628eb68236846c69"
+                "reference": "7575ef33b68a72a889ee83c75b61f3c7b8c4dcbd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Model/zipball/3033a55789fa96c58c69a6e9628eb68236846c69",
-                "reference": "3033a55789fa96c58c69a6e9628eb68236846c69",
+                "url": "https://api.github.com/repos/rancoud/Model/zipball/7575ef33b68a72a889ee83c75b61f3c7b8c4dcbd",
+                "reference": "7575ef33b68a72a889ee83c75b61f3c7b8c4dcbd",
                 "shasum": ""
             },
             "require": {
@@ -401,11 +401,11 @@
                 "ext-mbstring": "*",
                 "ext-pdo": "*",
                 "php": ">=7.4.0",
-                "rancoud/database": "^5.0 || ^6.0"
+                "rancoud/database": "^6.0"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.16 || ^3.0",
-                "phpunit/phpunit": "^9.1",
+                "phpunit/phpunit": "^9.1 || ^10.0 || ^11.0",
                 "squizlabs/php_codesniffer": "^3.5"
             },
             "suggest": {
@@ -432,9 +432,9 @@
             "description": "Model package",
             "support": {
                 "issues": "https://github.com/rancoud/Model/issues",
-                "source": "https://github.com/rancoud/Model/tree/4.1.5"
+                "source": "https://github.com/rancoud/Model/tree/4.1.6"
             },
-            "time": "2024-03-03T19:39:40+00:00"
+            "time": "2024-05-23T19:50:14+00:00"
         },
         {
             "name": "rancoud/pagination",

--- a/composer.lock
+++ b/composer.lock
@@ -234,16 +234,16 @@
         },
         {
             "name": "rancoud/database",
-            "version": "6.0.9",
+            "version": "6.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Database.git",
-                "reference": "b8eab4676ccfce8cd483cfcc6b0487d57f18aae7"
+                "reference": "0e814d9d4d94d67c89571fe004c30c8df6fae0a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Database/zipball/b8eab4676ccfce8cd483cfcc6b0487d57f18aae7",
-                "reference": "b8eab4676ccfce8cd483cfcc6b0487d57f18aae7",
+                "url": "https://api.github.com/repos/rancoud/Database/zipball/0e814d9d4d94d67c89571fe004c30c8df6fae0a9",
+                "reference": "0e814d9d4d94d67c89571fe004c30c8df6fae0a9",
                 "shasum": ""
             },
             "require": {
@@ -252,7 +252,7 @@
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.16 || ^3.0",
-                "phpunit/phpunit": "^9.1",
+                "phpunit/phpunit": "^9.1 || ^10.0 || ^11.0",
                 "squizlabs/php_codesniffer": "^3.5"
             },
             "suggest": {
@@ -279,9 +279,9 @@
             "description": "Database package",
             "support": {
                 "issues": "https://github.com/rancoud/Database/issues",
-                "source": "https://github.com/rancoud/Database/tree/6.0.9"
+                "source": "https://github.com/rancoud/Database/tree/6.0.10"
             },
-            "time": "2024-03-03T19:21:31+00:00"
+            "time": "2024-05-23T15:59:47+00:00"
         },
         {
             "name": "rancoud/environment",

--- a/composer.lock
+++ b/composer.lock
@@ -285,16 +285,16 @@
         },
         {
             "name": "rancoud/environment",
-            "version": "2.1.10",
+            "version": "2.1.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Environment.git",
-                "reference": "81d98ace065a952db6c79bdb05d0c81ddd941212"
+                "reference": "dd55a5c7d1aa8e3c464f7ab84857687b3ee01ce7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Environment/zipball/81d98ace065a952db6c79bdb05d0c81ddd941212",
-                "reference": "81d98ace065a952db6c79bdb05d0c81ddd941212",
+                "url": "https://api.github.com/repos/rancoud/Environment/zipball/dd55a5c7d1aa8e3c464f7ab84857687b3ee01ce7",
+                "reference": "dd55a5c7d1aa8e3c464f7ab84857687b3ee01ce7",
                 "shasum": ""
             },
             "require": {
@@ -303,7 +303,7 @@
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.16 || ^3.0",
-                "phpunit/phpunit": "^9.1",
+                "phpunit/phpunit": "^9.1 || ^10.0 || ^11.0",
                 "squizlabs/php_codesniffer": "^3.5"
             },
             "type": "library",
@@ -325,9 +325,9 @@
             "description": "Environment package",
             "support": {
                 "issues": "https://github.com/rancoud/Environment/issues",
-                "source": "https://github.com/rancoud/Environment/tree/2.1.10"
+                "source": "https://github.com/rancoud/Environment/tree/2.1.11"
             },
-            "time": "2024-03-03T20:27:54+00:00"
+            "time": "2024-05-23T16:00:41+00:00"
         },
         {
             "name": "rancoud/http",

--- a/composer.lock
+++ b/composer.lock
@@ -139,16 +139,16 @@
         },
         {
             "name": "rancoud/application",
-            "version": "5.2.6",
+            "version": "5.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Application.git",
-                "reference": "15bd406130018a8b97154f8a3a223ef42aa57dbe"
+                "reference": "71dbd2377733aeba5521a881b1ae515e2908e21e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Application/zipball/15bd406130018a8b97154f8a3a223ef42aa57dbe",
-                "reference": "15bd406130018a8b97154f8a3a223ef42aa57dbe",
+                "url": "https://api.github.com/repos/rancoud/Application/zipball/71dbd2377733aeba5521a881b1ae515e2908e21e",
+                "reference": "71dbd2377733aeba5521a881b1ae515e2908e21e",
                 "shasum": ""
             },
             "require": {
@@ -158,9 +158,9 @@
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.16 || ^3.0",
-                "phpunit/phpunit": "^9.1",
-                "rancoud/database": "^5.0 || ^6.0",
-                "rancoud/session": "^3.0 || ^4.0 || ^5.0",
+                "phpunit/phpunit": "^9.1 || ^10.0 || ^11.0",
+                "rancoud/database": "^6.0",
+                "rancoud/session": "^5.0",
                 "squizlabs/php_codesniffer": "^3.5"
             },
             "type": "library",
@@ -182,9 +182,9 @@
             "description": "Application package",
             "support": {
                 "issues": "https://github.com/rancoud/Application/issues",
-                "source": "https://github.com/rancoud/Application/tree/5.2.6"
+                "source": "https://github.com/rancoud/Application/tree/5.2.7"
             },
-            "time": "2024-03-03T21:16:52+00:00"
+            "time": "2024-05-23T21:30:37+00:00"
         },
         {
             "name": "rancoud/crypt",

--- a/composer.lock
+++ b/composer.lock
@@ -331,16 +331,16 @@
         },
         {
             "name": "rancoud/http",
-            "version": "3.2.2",
+            "version": "3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Http.git",
-                "reference": "ea5e0882533da98fb051fa187fedaa396f31da75"
+                "reference": "b275d34c73c1ad88241a9e21f722337fcb1ca86c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Http/zipball/ea5e0882533da98fb051fa187fedaa396f31da75",
-                "reference": "ea5e0882533da98fb051fa187fedaa396f31da75",
+                "url": "https://api.github.com/repos/rancoud/Http/zipball/b275d34c73c1ad88241a9e21f722337fcb1ca86c",
+                "reference": "b275d34c73c1ad88241a9e21f722337fcb1ca86c",
                 "shasum": ""
             },
             "require": {
@@ -354,7 +354,7 @@
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.16 || ^3.0",
-                "phpunit/phpunit": "^9.2",
+                "phpunit/phpunit": "^9.2 || ^10.0 || ^11.0",
                 "squizlabs/php_codesniffer": "^3.5",
                 "symfony/process": "^5.2"
             },
@@ -378,9 +378,9 @@
             "description": "Http package",
             "support": {
                 "issues": "https://github.com/rancoud/Http/issues",
-                "source": "https://github.com/rancoud/Http/tree/3.2.2"
+                "source": "https://github.com/rancoud/Http/tree/3.2.3"
             },
-            "time": "2024-03-03T20:42:02+00:00"
+            "time": "2024-05-23T16:00:44+00:00"
         },
         {
             "name": "rancoud/model",

--- a/composer.lock
+++ b/composer.lock
@@ -438,16 +438,16 @@
         },
         {
             "name": "rancoud/pagination",
-            "version": "3.1.6",
+            "version": "3.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Pagination.git",
-                "reference": "b7415b334350e133e25e24671a4aac905d2a42c0"
+                "reference": "f5443aaace7cd413c22f3a6ae6fd13738e04ba1e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Pagination/zipball/b7415b334350e133e25e24671a4aac905d2a42c0",
-                "reference": "b7415b334350e133e25e24671a4aac905d2a42c0",
+                "url": "https://api.github.com/repos/rancoud/Pagination/zipball/f5443aaace7cd413c22f3a6ae6fd13738e04ba1e",
+                "reference": "f5443aaace7cd413c22f3a6ae6fd13738e04ba1e",
                 "shasum": ""
             },
             "require": {
@@ -457,7 +457,7 @@
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.16 || ^3.0",
-                "phpunit/phpunit": "^9.1",
+                "phpunit/phpunit": "^9.1 || ^10.0 || ^11.0",
                 "squizlabs/php_codesniffer": "^3.5"
             },
             "type": "library",
@@ -479,9 +479,9 @@
             "description": "Pagination package",
             "support": {
                 "issues": "https://github.com/rancoud/Pagination/issues",
-                "source": "https://github.com/rancoud/Pagination/tree/3.1.6"
+                "source": "https://github.com/rancoud/Pagination/tree/3.1.7"
             },
-            "time": "2024-03-03T19:03:39+00:00"
+            "time": "2024-05-23T18:29:48+00:00"
         },
         {
             "name": "rancoud/router",

--- a/composer.lock
+++ b/composer.lock
@@ -531,16 +531,16 @@
         },
         {
             "name": "rancoud/security",
-            "version": "3.0.11",
+            "version": "3.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Security.git",
-                "reference": "855e55e3fd194207690a102487807d280d63f5cc"
+                "reference": "b3acd0f8d498ec1301c04d37f78f0a36c4f8a16a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Security/zipball/855e55e3fd194207690a102487807d280d63f5cc",
-                "reference": "855e55e3fd194207690a102487807d280d63f5cc",
+                "url": "https://api.github.com/repos/rancoud/Security/zipball/b3acd0f8d498ec1301c04d37f78f0a36c4f8a16a",
+                "reference": "b3acd0f8d498ec1301c04d37f78f0a36c4f8a16a",
                 "shasum": ""
             },
             "require": {
@@ -549,7 +549,7 @@
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.16 || ^3.0",
-                "phpunit/phpunit": "^9.1",
+                "phpunit/phpunit": "^9.1 || ^10.0 || ^11.0",
                 "squizlabs/php_codesniffer": "^3.5"
             },
             "type": "library",
@@ -571,9 +571,9 @@
             "description": "Security package",
             "support": {
                 "issues": "https://github.com/rancoud/Security/issues",
-                "source": "https://github.com/rancoud/Security/tree/3.0.11"
+                "source": "https://github.com/rancoud/Security/tree/3.0.12"
             },
-            "time": "2024-03-03T18:41:11+00:00"
+            "time": "2024-05-23T15:59:28+00:00"
         },
         {
             "name": "rancoud/session",

--- a/composer.lock
+++ b/composer.lock
@@ -577,16 +577,16 @@
         },
         {
             "name": "rancoud/session",
-            "version": "5.0.6",
+            "version": "5.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Session.git",
-                "reference": "38758dc43e8fcf06a17b1e337bbf9969e3e04183"
+                "reference": "91c072bd6b21f65317487de88b8d71088eabe232"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Session/zipball/38758dc43e8fcf06a17b1e337bbf9969e3e04183",
-                "reference": "38758dc43e8fcf06a17b1e337bbf9969e3e04183",
+                "url": "https://api.github.com/repos/rancoud/Session/zipball/91c072bd6b21f65317487de88b8d71088eabe232",
+                "reference": "91c072bd6b21f65317487de88b8d71088eabe232",
                 "shasum": ""
             },
             "require": {
@@ -597,9 +597,9 @@
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.16 || ^3.0",
-                "phpunit/phpunit": "^9.1",
+                "phpunit/phpunit": "^9.1 || ^10.0 || ^11.0",
                 "predis/predis": "^1.1 || ^2.0",
-                "rancoud/database": "^5.0 || ^6.0",
+                "rancoud/database": "^6.0",
                 "squizlabs/php_codesniffer": "^3.5"
             },
             "type": "library",
@@ -621,9 +621,9 @@
             "description": "Session package",
             "support": {
                 "issues": "https://github.com/rancoud/Session/issues",
-                "source": "https://github.com/rancoud/Session/tree/5.0.6"
+                "source": "https://github.com/rancoud/Session/tree/5.0.7"
             },
-            "time": "2024-03-03T20:19:48+00:00"
+            "time": "2024-05-23T21:04:28+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -188,16 +188,16 @@
         },
         {
             "name": "rancoud/crypt",
-            "version": "3.2.7",
+            "version": "3.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Crypt.git",
-                "reference": "d1658e20182c1f260a6b422ab5199fbb9f8e0048"
+                "reference": "3c8eda2761153e8e3c19b848d3b4b4c0fc206072"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Crypt/zipball/d1658e20182c1f260a6b422ab5199fbb9f8e0048",
-                "reference": "d1658e20182c1f260a6b422ab5199fbb9f8e0048",
+                "url": "https://api.github.com/repos/rancoud/Crypt/zipball/3c8eda2761153e8e3c19b848d3b4b4c0fc206072",
+                "reference": "3c8eda2761153e8e3c19b848d3b4b4c0fc206072",
                 "shasum": ""
             },
             "require": {
@@ -206,7 +206,7 @@
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.16 || ^3.0",
-                "phpunit/phpunit": "^9.1",
+                "phpunit/phpunit": "^9.1 || ^10.0 || ^11.0",
                 "squizlabs/php_codesniffer": "^3.5"
             },
             "type": "library",
@@ -228,9 +228,9 @@
             "description": "Crypt package",
             "support": {
                 "issues": "https://github.com/rancoud/Crypt/issues",
-                "source": "https://github.com/rancoud/Crypt/tree/3.2.7"
+                "source": "https://github.com/rancoud/Crypt/tree/3.2.8"
             },
-            "time": "2024-03-03T17:48:30+00:00"
+            "time": "2024-05-23T15:59:19+00:00"
         },
         {
             "name": "rancoud/database",


### PR DESCRIPTION
# Description
* bump rancoud/crypt from 3.2.7 to 3.2.8
* bump rancoud/security from 3.0.11 to 3.0.12
* bump rancoud/pagination from 3.1.6 to 3.1.7
* bump rancoud/database from 6.0.9 to 6.0.10
* bump rancoud/model from 4.1.5 to 4.1.6
* bump rancoud/session from 5.0.6 to 5.0.7
* bump rancoud/environment from 2.1.10 to 2.1.11
* bump rancoud/http from 3.2.2 to 3.2.3
* bump rancoud/router from 3.1.4 to 3.1.5
* bump rancoud/application from 5.2.6 to 5.2.7