### PR TITLE
chore: set alpine-s6 version to 3.19 instead of latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crazymax/alpine-s6:latest AS base
+FROM crazymax/alpine-s6:3.19 AS base
 
 ENV S6_BEHAVIOR_IF_STAGE2_FAILS="2" \
   TZ="UTC" \


### PR DESCRIPTION
# Description
I download today the last version and try to run the dev environment with the docker compose command.
But the container using PHP failing because it try to set PHP fpm 8.2 and the latest is using PHP 8.3.
So that pull request is to keep the PHP 8.2 and not to fail in the future.