### PR TITLE
fix: use correct label maildev for docker-composer-https.yml example

### DIFF
--- a/docker-examples/docker-compose-https.yml
+++ b/docker-examples/docker-compose-https.yml
@@ -43,7 +43,7 @@ services:
     container_name: blueprintue-self-hosted-edition
     depends_on:
       - mariadb
-      - msmtpd
+      - maildev
     ports:
       - "8000:8000"
     volumes:


### PR DESCRIPTION
relates #93