### PR TITLE
fix: access maildev via traefik in .dev/docker-compose.yml

### DIFF
--- a/.dev/docker-compose.yml
+++ b/.dev/docker-compose.yml
@@ -115,6 +115,8 @@ services:
       - "traefik.http.routers.maildev.entrypoints=http"
       - "traefik.http.routers.maildev.rule=Host(`maildev.blueprintue-self-hosted-edition.test`)"
       - "traefik.http.services.maildev.loadbalancer.server.port=1080"
+    environment:
+      MAILDEV_IP: "::"
 
 volumes:
   blueprintue-self-hosted-edition_db:


### PR DESCRIPTION
# Description
Maildev listens on IPv4 only, but with last version of Docker, it fail to return a correct healthcheck.
So it need to set an environment variable `MAILDEV_IP`.

It only affect the `.dev/docker-compose.yml`.