### PR TITLE
feat: add PHP 8.4

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,6 +23,7 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
 
     services:
       mysql:
@@ -60,4 +61,4 @@ jobs:
         if: success()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage/clover.xml
+          files: ./coverage/clover.xml

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -23,7 +23,7 @@ $rules = [
     'get_class_to_class_keyword'  => false,
     'global_namespace_import'     => false,
     'linebreak_after_opening_tag' => true,
-    'mb_str_functions'            => true, // turn off because of PHP 8.4
+    'mb_str_functions'            => false, // turn off because of PHP 8.4
     'native_function_invocation'  => [
         'include' => [
             '@all'

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -23,7 +23,7 @@ $rules = [
     'get_class_to_class_keyword'  => false,
     'global_namespace_import'     => false,
     'linebreak_after_opening_tag' => true,
-    'mb_str_functions'            => true,
+    'mb_str_functions'            => true, // turn off because of PHP 8.4
     'native_function_invocation'  => [
         'include' => [
             '@all'

--- a/app/controllers/www/APIController.php
+++ b/app/controllers/www/APIController.php
@@ -71,7 +71,7 @@ class APIController implements MiddlewareInterface
      */
     protected function findUserWithApiKey(ServerRequestInterface $request): array
     {
-        $apiKey = \trim($request->getHeaderLine('X-Token'));
+        $apiKey = Helper::trim($request->getHeaderLine('X-Token'));
         if ($apiKey === '') {
             return [null, 'api_key_empty'];
         }
@@ -122,7 +122,7 @@ class APIController implements MiddlewareInterface
             return null;
         }
 
-        $blueprint = \trim($rawParams['blueprint']);
+        $blueprint = Helper::trim($rawParams['blueprint']);
         if (!BlueprintService::isValidBlueprint($blueprint)) {
             return null;
         }
@@ -189,22 +189,22 @@ class APIController implements MiddlewareInterface
             return [null, 'invalid'];
         }
 
-        $title = \trim($rawParams['title'] ?? '');
+        $title = Helper::trim($rawParams['title'] ?? '');
         if ($title === '') {
             return [null, 'required_title'];
         }
 
-        $blueprint = \trim($rawParams['blueprint'] ?? '');
+        $blueprint = Helper::trim($rawParams['blueprint'] ?? '');
         if (!BlueprintService::isValidBlueprint($blueprint)) {
             return [null, 'invalid_blueprint'];
         }
 
-        $exposure = \trim($rawParams['exposure'] ?? 'public');
+        $exposure = Helper::trim($rawParams['exposure'] ?? 'public');
         if (!\in_array($exposure, ['public', 'unlisted', 'private'], true)) {
             return [null, 'invalid_exposure'];
         }
 
-        $expiration = \trim($rawParams['expiration'] ?? 'never');
+        $expiration = Helper::trim($rawParams['expiration'] ?? 'never');
         if (!\in_array($expiration, ['never', '3600', '86400', '604800'], true)) {
             return [null, 'invalid_expiration'];
         }
@@ -212,7 +212,7 @@ class APIController implements MiddlewareInterface
         $oldExpiration = ['never' => 'never', '3600' => '1h', '86400' => '1d', '604800' => '1w'];
         $expiration = $oldExpiration[$expiration];
 
-        $version = \trim($rawParams['version'] ?? Helper::getCurrentUEVersion());
+        $version = Helper::trim($rawParams['version'] ?? Helper::getCurrentUEVersion());
         if (!\in_array($version, Helper::getAllUEVersion(), true)) {
             return [null, 'invalid_version'];
         }

--- a/app/controllers/www/BlueprintController.php
+++ b/app/controllers/www/BlueprintController.php
@@ -527,7 +527,7 @@ class BlueprintController implements MiddlewareInterface
         $rawParams = $request->getParsedBody();
         foreach ($rawParams as $key => $rawParam) {
             if (\in_array($key, $htmlNames, true)) {
-                $params[$key] = \trim($rawParam);
+                $params[$key] = Helper::trim($rawParam);
             }
         }
 
@@ -627,7 +627,7 @@ class BlueprintController implements MiddlewareInterface
         $rawParams = $request->getParsedBody();
         foreach ($rawParams as $key => $rawParam) {
             if (\in_array($key, $htmlNames, true)) {
-                $params[$key] = \trim($rawParam);
+                $params[$key] = Helper::trim($rawParam);
             }
         }
 
@@ -733,7 +733,7 @@ class BlueprintController implements MiddlewareInterface
         $rawParams = $request->getParsedBody();
         foreach ($rawParams as $key => $rawParam) {
             if (\in_array($key, $htmlNames, true)) {
-                $params[$key] = \trim($rawParam);
+                $params[$key] = Helper::trim($rawParam);
             }
         }
 
@@ -841,7 +841,7 @@ class BlueprintController implements MiddlewareInterface
         $rawParams = $request->getParsedBody();
         foreach ($rawParams as $key => $rawParam) {
             if (\in_array($key, $htmlNames, true)) {
-                $params[$key] = \trim($rawParam);
+                $params[$key] = Helper::trim($rawParam);
             }
         }
 

--- a/app/controllers/www/BlueprintEditController.php
+++ b/app/controllers/www/BlueprintEditController.php
@@ -254,7 +254,7 @@ class BlueprintEditController implements MiddlewareInterface
         $rawParams = $request->getParsedBody();
         foreach ($rawParams as $key => $rawParam) {
             if (\in_array($key, $htmlNames, true)) {
-                $params[$key] = \trim($rawParam);
+                $params[$key] = Helper::trim($rawParam);
             }
         }
 

--- a/app/controllers/www/BlueprintListController.php
+++ b/app/controllers/www/BlueprintListController.php
@@ -233,9 +233,9 @@ class BlueprintListController implements MiddlewareInterface
 
         $this->params['query'] = '';
         if (isset($queryParams['query'])) {
-            $this->params['query'] = \trim($queryParams['query']);
+            $this->params['query'] = Helper::trim($queryParams['query']);
         } elseif (isset($queryParams['form-search-input-query'])) {
-            $this->params['query'] = \trim($queryParams['form-search-input-query']);
+            $this->params['query'] = Helper::trim($queryParams['form-search-input-query']);
         }
         if ($this->params['query'] !== '') {
             $urlParts[] = 'form-search-input-query=' . $this->params['query'];
@@ -243,7 +243,7 @@ class BlueprintListController implements MiddlewareInterface
 
         $this->params['type_slug'] = '';
         if (isset($queryParams['form-search-select-type']) && \in_array($queryParams['form-search-select-type'], ['animation', 'behavior-tree', 'blueprint', 'material', 'metasound', 'niagara', 'pcg'], true)) { // phpcs:ignore
-            $this->params['type_slug'] = \trim($queryParams['form-search-select-type']);
+            $this->params['type_slug'] = Helper::trim($queryParams['form-search-select-type']);
             $urlParts[] = 'form-search-select-type=' . $this->params['type_slug'];
 
             $this->params['type'] = $this->params['type_slug'];
@@ -254,7 +254,7 @@ class BlueprintListController implements MiddlewareInterface
 
         $this->params['ue_version'] = '';
         if (isset($queryParams['form-search-select-ue_version']) && \in_array($queryParams['form-search-select-ue_version'], Helper::getAllUEVersion(), true)) { // phpcs:ignore
-            $this->params['ue_version'] = \trim($queryParams['form-search-select-ue_version']);
+            $this->params['ue_version'] = Helper::trim($queryParams['form-search-select-ue_version']);
             $urlParts[] = 'form-search-select-ue_version=' . $this->params['ue_version'];
         }
 

--- a/app/controllers/www/ContactController.php
+++ b/app/controllers/www/ContactController.php
@@ -108,7 +108,7 @@ class ContactController implements MiddlewareInterface
         $rawParams = $request->getParsedBody();
         foreach ($rawParams as $key => $rawParam) {
             if (\in_array($key, $htmlNames, true)) {
-                $params[$key] = \trim($rawParam);
+                $params[$key] = Helper::trim($rawParam);
             }
         }
 

--- a/app/controllers/www/HomeController.php
+++ b/app/controllers/www/HomeController.php
@@ -99,7 +99,7 @@ class HomeController implements MiddlewareInterface
         $rawParams = $request->getParsedBody();
         foreach ($rawParams as $key => $rawParam) {
             if (\in_array($key, $htmlNames, true)) {
-                $params[$key] = \trim($rawParam);
+                $params[$key] = Helper::trim($rawParam);
             }
         }
 

--- a/app/controllers/www/ProfileEditController.php
+++ b/app/controllers/www/ProfileEditController.php
@@ -276,7 +276,7 @@ class ProfileEditController implements MiddlewareInterface
         $rawParams = $request->getParsedBody();
         foreach ($rawParams as $key => $rawParam) {
             if (\in_array($key, $htmlNames, true)) {
-                $params[$key] = \trim($rawParam);
+                $params[$key] = Helper::trim($rawParam);
             }
         }
 

--- a/app/controllers/www/ResetPasswordController.php
+++ b/app/controllers/www/ResetPasswordController.php
@@ -104,7 +104,7 @@ class ResetPasswordController implements MiddlewareInterface
         $rawParams = $request->getParsedBody();
         foreach ($rawParams as $key => $rawParam) {
             if (\in_array($key, $htmlNames, true)) {
-                $params[$key] = \trim($rawParam);
+                $params[$key] = Helper::trim($rawParam);
             }
         }
 
@@ -124,7 +124,7 @@ class ResetPasswordController implements MiddlewareInterface
         }
 
         // token
-        $values['token'] = \trim($request->getQueryParams()['reset_token']);
+        $values['token'] = Helper::trim($request->getQueryParams()['reset_token']);
 
         // password
         $values['password'] = $params[$this->inputs['password']];

--- a/app/helpers/Helper.php
+++ b/app/helpers/Helper.php
@@ -413,4 +413,21 @@ class Helper
     {
         return (new DateTime($date, new DateTimeZone($timezone)))->format($format);
     }
+
+    /**
+     * Because of PHP 8.4.
+     *
+     * @param        $string
+     * @param string $characters
+     *
+     * @return string
+     */
+    public static function trim($string, string $characters = " \n\r\t\v\0"): string
+    {
+        if (\PHP_MAJOR_VERSION >= 8 && \PHP_MINOR_VERSION >= 4) {
+            return \mb_trim((string) $string, $characters);
+        }
+
+        return \trim((string) $string, $characters);
+    }
 }

--- a/app/middlewares/ForgotPasswordMiddleware.php
+++ b/app/middlewares/ForgotPasswordMiddleware.php
@@ -67,7 +67,7 @@ class ForgotPasswordMiddleware implements MiddlewareInterface
         $rawParams = $request->getParsedBody();
         foreach ($rawParams as $key => $rawParam) {
             if (\in_array($key, $htmlNames, true)) {
-                $params[$key] = \trim($rawParam);
+                $params[$key] = Helper::trim($rawParam);
             }
         }
 

--- a/app/middlewares/LoginMiddleware.php
+++ b/app/middlewares/LoginMiddleware.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace app\middlewares;
 
 use app\controllers\FormTrait;
+use app\helpers\Helper;
 use app\services\www\UserService;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -71,7 +72,7 @@ class LoginMiddleware implements MiddlewareInterface
         $rawParams = $request->getParsedBody();
         foreach ($rawParams as $key => $rawParam) {
             if (\in_array($key, $htmlNames, true)) {
-                $params[$key] = \trim($rawParam);
+                $params[$key] = Helper::trim($rawParam);
             }
         }
 

--- a/app/middlewares/RegisterMiddleware.php
+++ b/app/middlewares/RegisterMiddleware.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace app\middlewares;
 
 use app\controllers\FormTrait;
+use app\helpers\Helper;
 use app\services\www\UserService;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -66,7 +67,7 @@ class RegisterMiddleware implements MiddlewareInterface
         $rawParams = $request->getParsedBody();
         foreach ($rawParams as $key => $rawParam) {
             if (\in_array($key, $htmlNames, true)) {
-                $params[$key] = \trim($rawParam);
+                $params[$key] = Helper::trim($rawParam);
             }
         }
 

--- a/app/models/TagModel.php
+++ b/app/models/TagModel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace app\models;
 
+use app\helpers\Helper;
 use Rancoud\Model\Field;
 use Rancoud\Model\FieldException;
 use Rancoud\Model\Model;
@@ -37,7 +38,7 @@ class TagModel extends Model
      */
     public function getTagsWithListIDs(string $listIDs): ?array
     {
-        $listIDs = \trim($listIDs);
+        $listIDs = Helper::trim($listIDs);
         if (empty($listIDs)) {
             // @codeCoverageIgnoreStart
             /*

--- a/app/services/www/TagService.php
+++ b/app/services/www/TagService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace app\services\www;
 
+use app\helpers\Helper;
 use app\models\TagModel;
 use Rancoud\Application\Application;
 
@@ -18,7 +19,7 @@ class TagService
      */
     public static function slugify(string $string): string
     {
-        $string = \trim($string);
+        $string = Helper::trim($string);
         $string = \mb_strtolower($string);
         $string = \str_replace(['.', ' ', '@'], ['-', '-', ''], $string);
 
@@ -90,7 +91,7 @@ class TagService
         $tagsToSeek = [];
         $itemsCount = 0;
         foreach ($tagsRaw as $tagRaw) {
-            $tagRaw = \trim($tagRaw);
+            $tagRaw = Helper::trim($tagRaw);
             if ($tagRaw === '') {
                 continue;
             }

--- a/app/services/www/UserService.php
+++ b/app/services/www/UserService.php
@@ -511,7 +511,7 @@ class UserService
      */
     public static function slugify(string $string): string
     {
-        $string = \trim($string);
+        $string = Helper::trim($string);
         $string = \mb_strtolower($string);
         $string = \str_replace(['.', ' ', '@'], ['-', '-', ''], $string);
 

--- a/tests/www/Blueprint/Edit/BlueprintEditPOSTAddVersionTest.php
+++ b/tests/www/Blueprint/Edit/BlueprintEditPOSTAddVersionTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace tests\www\Blueprint\Edit;
 
+use app\helpers\Helper;
 use PHPUnit\Framework\TestCase;
 use Rancoud\Application\ApplicationException;
 use Rancoud\Crypt\Crypt;
@@ -576,12 +577,12 @@ class BlueprintEditPOSTAddVersionTest extends TestCase
             $labelError = $fieldsLabelError[$field] ?? '';
 
             if ($field === 'blueprint') {
-                $value = $hasValue ? \trim($params['form-add_version-textarea-blueprint']) : '';
+                $value = $hasValue ? Helper::trim($params['form-add_version-textarea-blueprint']) : '';
                 $this->doTestHtmlForm($response, '#form-add_version', $this->getHTMLFieldBlueprint($value, $hasError, $labelError));
             }
 
             if ($field === 'reason') {
-                $value = $hasValue ? \trim($params['form-add_version-textarea-reason']) : '';
+                $value = $hasValue ? Helper::trim($params['form-add_version-textarea-reason']) : '';
                 $this->doTestHtmlForm($response, '#form-add_version', $this->getHTMLFieldReason($value, $hasError, $labelError));
             }
         }

--- a/tests/www/Blueprint/Edit/BlueprintEditPOSTDeleteBlueprintTest.php
+++ b/tests/www/Blueprint/Edit/BlueprintEditPOSTDeleteBlueprintTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace tests\www\Blueprint\Edit;
 
+use app\helpers\Helper;
 use PHPUnit\Framework\TestCase;
 use Rancoud\Application\Application;
 use Rancoud\Application\ApplicationException;
@@ -613,7 +614,7 @@ class BlueprintEditPOSTDeleteBlueprintTest extends TestCase
             $labelError = $fieldsLabelError[$field] ?? '';
 
             if ($field === 'ownership') {
-                $value = $hasValue ? \trim($params['form-delete_blueprint-select-ownership']) : '';
+                $value = $hasValue ? Helper::trim($params['form-delete_blueprint-select-ownership']) : '';
                 $this->doTestHtmlForm($response, '#form-delete_blueprint', $this->getHTMLFieldOwnership($value, $hasError, $labelError, $blueprintBefore['exposure'] === 'private'));
             }
         }

--- a/tests/www/Blueprint/Edit/BlueprintEditPOSTEditInformationsTest.php
+++ b/tests/www/Blueprint/Edit/BlueprintEditPOSTEditInformationsTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace tests\www\Blueprint\Edit;
 
+use app\helpers\Helper;
 use PHPUnit\Framework\TestCase;
 use Rancoud\Application\ApplicationException;
 use Rancoud\Crypt\Crypt;
@@ -894,16 +895,16 @@ class BlueprintEditPOSTEditInformationsTest extends TestCase
 
         if ($isFormSuccess) {
             // title
-            static::assertSame(\trim($params['form-edit_informations-input-title']), $blueprintAfter['title']);
+            static::assertSame(Helper::trim($params['form-edit_informations-input-title']), $blueprintAfter['title']);
 
             // description
-            if (\trim($params['form-edit_informations-textarea-description']) === '') {
+            if (Helper::trim($params['form-edit_informations-textarea-description']) === '') {
                 static::assertNull($blueprintAfter['description']);
             } else {
-                static::assertSame(\trim($params['form-edit_informations-textarea-description']), $blueprintAfter['description']);
+                static::assertSame(Helper::trim($params['form-edit_informations-textarea-description']), $blueprintAfter['description']);
             }
 
-            if (\trim($params['form-edit_informations-textarea-tags']) === '') {
+            if (Helper::trim($params['form-edit_informations-textarea-tags']) === '') {
                 static::assertNull($blueprintAfter['tags']);
             } else {
                 $tagIDs = [];
@@ -929,7 +930,7 @@ class BlueprintEditPOSTEditInformationsTest extends TestCase
             }
 
             // video
-            if (\trim($params['form-edit_informations-input-video']) === '') {
+            if (Helper::trim($params['form-edit_informations-input-video']) === '') {
                 static::assertNull($blueprintAfter['video']);
                 static::assertNull($blueprintAfter['video_provider']);
             } elseif ($params['form-edit_informations-input-video'] === 'youtu.be/5qap5aO4i9A' || $params['form-edit_informations-input-video'] === 'youtu.be/5qap5aO4i9A&=<script>alert(1)</script>"/><script>alert(1)</script>') {
@@ -969,7 +970,7 @@ class BlueprintEditPOSTEditInformationsTest extends TestCase
 
             if ($field === 'title') {
                 if (isset($params['form-edit_informations-input-title'])) {
-                    $value = $hasValue ? \trim($params['form-edit_informations-input-title']) : '';
+                    $value = $hasValue ? Helper::trim($params['form-edit_informations-input-title']) : '';
                     if ($params['form-edit_informations-input-title'] === \chr(99999999)) {
                         $value = 'title_1';
                     }
@@ -980,7 +981,7 @@ class BlueprintEditPOSTEditInformationsTest extends TestCase
             }
 
             if ($field === 'description') {
-                $value = $hasValue ? \trim($params['form-edit_informations-textarea-description']) : '';
+                $value = $hasValue ? Helper::trim($params['form-edit_informations-textarea-description']) : '';
                 if (isset($params['form-edit_informations-textarea-description']) && $params['form-edit_informations-textarea-description'] === \chr(99999999)) {
                     $value = '';
                 }
@@ -995,7 +996,7 @@ class BlueprintEditPOSTEditInformationsTest extends TestCase
             }
 
             if ($field === 'video') {
-                $value = $hasValue ? \trim($params['form-edit_informations-input-video']) : '';
+                $value = $hasValue ? Helper::trim($params['form-edit_informations-input-video']) : '';
                 if (isset($params['form-edit_informations-input-video']) && $params['form-edit_informations-input-video'] === \chr(99999999)) {
                     $value = '';
                 }

--- a/tests/www/Blueprint/Edit/BlueprintEditPOSTEditPropertiesTest.php
+++ b/tests/www/Blueprint/Edit/BlueprintEditPOSTEditPropertiesTest.php
@@ -1131,7 +1131,7 @@ class BlueprintEditPOSTEditPropertiesTest extends TestCase
 
             if ($field === 'exposure') {
                 if (isset($params['form-edit_properties-select-exposure']) && $params['form-edit_properties-select-exposure'] !== \chr(99999999)) {
-                    $value = $hasValue ? \trim($params['form-edit_properties-select-exposure']) : '';
+                    $value = $hasValue ? Helper::trim($params['form-edit_properties-select-exposure']) : '';
                 } else {
                     $value = 'private';
                 }
@@ -1142,7 +1142,7 @@ class BlueprintEditPOSTEditPropertiesTest extends TestCase
                 if ($isFormSuccess) {
                     $value = '';
                 } elseif (isset($params['form-edit_properties-select-expiration']) && $params['form-edit_properties-select-expiration'] !== \chr(99999999)) {
-                    $value = $hasValue ? \trim($params['form-edit_properties-select-expiration']) : '';
+                    $value = $hasValue ? Helper::trim($params['form-edit_properties-select-expiration']) : '';
                 } else {
                     $value = '';
                 }
@@ -1151,7 +1151,7 @@ class BlueprintEditPOSTEditPropertiesTest extends TestCase
 
             if ($field === 'ue_version') {
                 if (isset($params['form-edit_properties-select-ue_version']) && $params['form-edit_properties-select-ue_version'] !== \chr(99999999)) {
-                    $value = $hasValue ? \trim($params['form-edit_properties-select-ue_version']) : '';
+                    $value = $hasValue ? Helper::trim($params['form-edit_properties-select-ue_version']) : '';
                 } else {
                     $value = '4.0';
                 }
@@ -1160,7 +1160,7 @@ class BlueprintEditPOSTEditPropertiesTest extends TestCase
 
             if ($field === 'comment') {
                 if (isset($params['form-edit_properties-select-comment']) && $params['form-edit_properties-select-comment'] !== \chr(99999999)) {
-                    $value = $hasValue ? \trim($params['form-edit_properties-select-comment']) : '';
+                    $value = $hasValue ? Helper::trim($params['form-edit_properties-select-comment']) : '';
                 } else {
                     $value = 'open';
                 }

--- a/tests/www/Blueprint/View/BlueprintPOSTAddCommentTest.php
+++ b/tests/www/Blueprint/View/BlueprintPOSTAddCommentTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace tests\www\Blueprint\View;
 
+use app\helpers\Helper;
 use PHPUnit\Framework\TestCase;
 use Rancoud\Application\ApplicationException;
 use Rancoud\Database\DatabaseException;
@@ -521,7 +522,7 @@ class BlueprintPOSTAddCommentTest extends TestCase
             $labelError = $fieldsLabelError[$field] ?? '';
 
             if ($field === 'comment') {
-                $value = $hasValue ? \trim($params['form-add_comment-textarea-comment']) : '';
+                $value = $hasValue ? Helper::trim($params['form-add_comment-textarea-comment']) : '';
                 $this->doTestHtmlMain($response, $this->getHTMLFormAddComment($value, $hasError, $labelError));
             }
         }

--- a/tests/www/Blueprint/View/BlueprintPOSTEditCommentTest.php
+++ b/tests/www/Blueprint/View/BlueprintPOSTEditCommentTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace tests\www\Blueprint\View;
 
+use app\helpers\Helper;
 use PHPUnit\Framework\TestCase;
 use Rancoud\Application\ApplicationException;
 use Rancoud\Database\DatabaseException;
@@ -701,7 +702,7 @@ HTML;
 
             if ($field === 'comment') {
                 if ($isFormSuccess) {
-                    $value = $hasValue ? \trim($params['form-edit_comment-textarea-comment']) : '';
+                    $value = $hasValue ? Helper::trim($params['form-edit_comment-textarea-comment']) : '';
                 } elseif (isset($params['form-edit_comment-textarea-comment']) && $params['form-edit_comment-textarea-comment'] === ' ') {
                     $value = '';
                 } else {

--- a/tests/www/Contact/ContactTest.php
+++ b/tests/www/Contact/ContactTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace tests\www\Contact;
 
+use app\helpers\Helper;
 use PHPUnit\Framework\TestCase;
 use Rancoud\Application\ApplicationException;
 use Rancoud\Environment\EnvironmentException;
@@ -610,17 +611,17 @@ class ContactTest extends TestCase
             $labelError = $fieldsLabelError[$field] ?? '';
 
             if ($field === 'name') {
-                $value = $hasValue ? \trim($params['form-contact-input-name']) : '';
+                $value = $hasValue ? Helper::trim($params['form-contact-input-name']) : '';
                 $this->doTestHtmlForm($response, '/contact/', $this->getHTMLFieldName($value, $hasError, $labelError));
             }
 
             if ($field === 'email') {
-                $value = $hasValue ? \trim($params['form-contact-input-email']) : '';
+                $value = $hasValue ? Helper::trim($params['form-contact-input-email']) : '';
                 $this->doTestHtmlForm($response, '/contact/', $this->getHTMLFieldEmail($value, $hasError, $labelError));
             }
 
             if ($field === 'message') {
-                $value = $hasValue ? \trim($params['form-contact-textarea-message']) : '';
+                $value = $hasValue ? Helper::trim($params['form-contact-textarea-message']) : '';
                 $this->doTestHtmlForm($response, '/contact/', $this->getHTMLFieldMessage($value, $hasError, $labelError));
             }
         }

--- a/tests/www/ForgotPassword/ForgotPasswordTest.php
+++ b/tests/www/ForgotPassword/ForgotPasswordTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace tests\www\ForgotPassword;
 
+use app\helpers\Helper;
 use DateTime;
 use DateTimeZone;
 use PHPUnit\Framework\TestCase;
@@ -523,7 +524,7 @@ class ForgotPasswordTest extends TestCase
                 $labelError = $fieldsLabelError[$field] ?? '';
 
                 if ($field === 'email') {
-                    $value = $hasValue ? \trim($params['form-forgot_password-input-email']) : '';
+                    $value = $hasValue ? Helper::trim($params['form-forgot_password-input-email']) : '';
                     $this->doTestHtmlForm($response, '#popin-forgot_password', $this->getHTMLFieldEmail($value, $hasError, $labelError));
                 }
             }

--- a/tests/www/ForgotPassword/ResetPasswordTest.php
+++ b/tests/www/ForgotPassword/ResetPasswordTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace tests\www\ForgotPassword;
 
+use app\helpers\Helper;
 use PHPUnit\Framework\TestCase;
 use Rancoud\Application\ApplicationException;
 use Rancoud\Crypt\Crypt;
@@ -837,7 +838,7 @@ HTML);
             $labelError = $fieldsLabelError[$field] ?? '';
 
             if ($field === 'email') {
-                $value = $hasValue ? \trim($params['form-reset_password-input-email']) : '';
+                $value = $hasValue ? Helper::trim($params['form-reset_password-input-email']) : '';
                 $this->doTestHtmlForm($response, '/reset-password/?reset_token=' . Security::escAttr($resetToken), $this->getHTMLFieldEmail($value, $hasError, $labelError));
             }
 

--- a/tests/www/Home/HomeTest.php
+++ b/tests/www/Home/HomeTest.php
@@ -1086,27 +1086,27 @@ class HomeTest extends TestCase
             $labelError = $fieldsLabelError[$field] ?? '';
 
             if ($field === 'title') {
-                $value = $hasValue ? \trim($params['form-add_blueprint-input-title']) : '';
+                $value = $hasValue ? Helper::trim($params['form-add_blueprint-input-title']) : '';
                 $this->doTestHtmlForm($response, '/', $this->getHTMLFieldTitle($value, $hasError, $labelError));
             }
 
             if ($field === 'exposure') {
-                $value = $hasValue ? \trim($params['form-add_blueprint-select-exposure']) : '';
+                $value = $hasValue ? Helper::trim($params['form-add_blueprint-select-exposure']) : '';
                 $this->doTestHtmlForm($response, '/', $this->getHTMLFieldExposure($value, $hasError, $labelError));
             }
 
             if ($field === 'expiration') {
-                $value = $hasValue ? \trim($params['form-add_blueprint-select-expiration']) : '';
+                $value = $hasValue ? Helper::trim($params['form-add_blueprint-select-expiration']) : '';
                 $this->doTestHtmlForm($response, '/', $this->getHTMLFieldExpiration($value, $hasError, $labelError));
             }
 
             if ($field === 'ue_version') {
-                $value = $hasValue ? \trim($params['form-add_blueprint-select-ue_version']) : '';
+                $value = $hasValue ? Helper::trim($params['form-add_blueprint-select-ue_version']) : '';
                 $this->doTestHtmlForm($response, '/', $this->getHTMLFieldUEVersion($value, $hasError, $labelError));
             }
 
             if ($field === 'blueprint') {
-                $value = $hasValue ? \trim($params['form-add_blueprint-textarea-blueprint']) : '';
+                $value = $hasValue ? Helper::trim($params['form-add_blueprint-textarea-blueprint']) : '';
                 $this->doTestHtmlForm($response, '/', $this->getHTMLFieldBlueprint($value, $hasError, $labelError));
             }
         }

--- a/tests/www/Profile/Edit/ProfileEditPOSTChangeEmailTest.php
+++ b/tests/www/Profile/Edit/ProfileEditPOSTChangeEmailTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace tests\www\Profile\Edit;
 
+use app\helpers\Helper;
 use PHPUnit\Framework\TestCase;
 use Rancoud\Application\ApplicationException;
 use Rancoud\Crypt\Crypt;
@@ -394,7 +395,7 @@ class ProfileEditPOSTChangeEmailTest extends TestCase
 
         if ($isFormSuccess) {
             static::assertNotSame($userBefore, $userAfter);
-            static::assertSame(\trim($params['form-change_email-input-new_email']), $userAfter['email']);
+            static::assertSame(Helper::trim($params['form-change_email-input-new_email']), $userAfter['email']);
         } else {
             static::assertSame($userBefore, $userAfter);
         }
@@ -435,7 +436,7 @@ HTML);
             $labelError = $fieldsLabelError[$field] ?? '';
 
             if ($field === 'new_email') {
-                $value = $hasValue ? \trim($params['form-change_email-input-new_email']) : '';
+                $value = $hasValue ? Helper::trim($params['form-change_email-input-new_email']) : '';
                 $this->doTestHtmlForm($response, '#form-change_email', $this->getHTMLFieldNewEmail($value, $hasError, $labelError));
             }
         }

--- a/tests/www/Profile/Edit/ProfileEditPOSTChangeUsernameTest.php
+++ b/tests/www/Profile/Edit/ProfileEditPOSTChangeUsernameTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace tests\www\Profile\Edit;
 
+use app\helpers\Helper;
 use PHPUnit\Framework\TestCase;
 use Rancoud\Application\ApplicationException;
 use Rancoud\Crypt\Crypt;
@@ -411,7 +412,7 @@ class ProfileEditPOSTChangeUsernameTest extends TestCase
 
         if ($isFormSuccess) {
             static::assertNotSame($userBefore, $userAfter);
-            static::assertSame(\trim($params['form-change_username-input-new_username']), $userAfter['username']);
+            static::assertSame(Helper::trim($params['form-change_username-input-new_username']), $userAfter['username']);
         } else {
             static::assertSame($userBefore, $userAfter);
         }
@@ -446,7 +447,7 @@ HTML);
             $labelError = $fieldsLabelError[$field] ?? '';
 
             if ($field === 'new_username') {
-                $value = $hasValue ? \trim($params['form-change_username-input-new_username']) : '';
+                $value = $hasValue ? Helper::trim($params['form-change_username-input-new_username']) : '';
                 $this->doTestHtmlForm($response, '#form-change_username', $this->getHTMLFieldNewUsername($value, $hasError, $labelError));
             }
         }

--- a/tests/www/Profile/Edit/ProfileEditPOSTDeleteProfileTest.php
+++ b/tests/www/Profile/Edit/ProfileEditPOSTDeleteProfileTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace tests\www\Profile\Edit;
 
+use app\helpers\Helper;
 use PHPUnit\Framework\TestCase;
 use Rancoud\Application\Application;
 use Rancoud\Application\ApplicationException;
@@ -931,12 +932,12 @@ class ProfileEditPOSTDeleteProfileTest extends TestCase
             $labelError = $fieldsLabelError[$field] ?? '';
 
             if ($field === 'blueprints_ownership') {
-                $value = $hasValue ? \trim($params['form-delete_profile-select-blueprints_ownership']) : '';
+                $value = $hasValue ? Helper::trim($params['form-delete_profile-select-blueprints_ownership']) : '';
                 $this->doTestHtmlForm($response, '#form-delete_profile', $this->getHTMLFieldBlueprintsOwnership($value, $hasError, $labelError));
             }
 
             if ($field === 'comments_ownership') {
-                $value = $hasValue ? \trim($params['form-delete_profile-select-comments_ownership']) : '';
+                $value = $hasValue ? Helper::trim($params['form-delete_profile-select-comments_ownership']) : '';
                 $this->doTestHtmlForm($response, '#form-delete_profile', $this->getHTMLFieldCommentsOwnership($value, $hasError, $labelError));
             }
         }

--- a/tests/www/Profile/Edit/ProfileEditPOSTEditBasicInfosTest.php
+++ b/tests/www/Profile/Edit/ProfileEditPOSTEditBasicInfosTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace tests\www\Profile\Edit;
 
+use app\helpers\Helper;
 use PHPUnit\Framework\TestCase;
 use Rancoud\Application\ApplicationException;
 use Rancoud\Crypt\Crypt;
@@ -437,8 +438,8 @@ class ProfileEditPOSTEditBasicInfosTest extends TestCase
 
         if ($isFormSuccess) {
             static::assertNotSame($usersInfosBefore, $usersInfosAfter);
-            static::assertSame(\trim($params['form-edit_basic_infos-textarea-bio']), $usersInfosAfter['bio']);
-            static::assertSame(\trim($params['form-edit_basic_infos-input-website']), $usersInfosAfter['link_website']);
+            static::assertSame(Helper::trim($params['form-edit_basic_infos-textarea-bio']), $usersInfosAfter['bio']);
+            static::assertSame(Helper::trim($params['form-edit_basic_infos-input-website']), $usersInfosAfter['link_website']);
         } else {
             static::assertSame($usersInfosBefore, $usersInfosAfter);
         }
@@ -463,12 +464,12 @@ class ProfileEditPOSTEditBasicInfosTest extends TestCase
             $hasValue = \in_array($field, $fieldsHasValue, true);
 
             if ($field === 'bio') {
-                $value = $hasValue ? \trim($params['form-edit_basic_infos-textarea-bio']) : '';
+                $value = $hasValue ? Helper::trim($params['form-edit_basic_infos-textarea-bio']) : '';
                 $this->doTestHtmlForm($response, '#form-edit_basic_infos', $this->getHTMLFieldBio($value));
             }
 
             if ($field === 'website') {
-                $value = $hasValue ? \trim($params['form-edit_basic_infos-input-website']) : '';
+                $value = $hasValue ? Helper::trim($params['form-edit_basic_infos-input-website']) : '';
                 $this->doTestHtmlForm($response, '#form-edit_basic_infos', $this->getHTMLFieldWebsite($value));
             }
         }

--- a/tests/www/Profile/Edit/ProfileEditPOSTEditSocialsTest.php
+++ b/tests/www/Profile/Edit/ProfileEditPOSTEditSocialsTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace tests\www\Profile\Edit;
 
+use app\helpers\Helper;
 use PHPUnit\Framework\TestCase;
 use Rancoud\Application\ApplicationException;
 use Rancoud\Crypt\Crypt;
@@ -1053,12 +1054,12 @@ class ProfileEditPOSTEditSocialsTest extends TestCase
 
         if ($isFormSuccess) {
             static::assertNotSame($usersInfosBefore, $usersInfosAfter);
-            static::assertSame(\trim($params['form-edit_socials-input-facebook']), $usersInfosAfter['link_facebook']);
-            static::assertSame(\trim($params['form-edit_socials-input-twitter']), $usersInfosAfter['link_twitter']);
-            static::assertSame(\trim($params['form-edit_socials-input-github']), $usersInfosAfter['link_github']);
-            static::assertSame(\trim($params['form-edit_socials-input-youtube']), $usersInfosAfter['link_youtube']);
-            static::assertSame(\trim($params['form-edit_socials-input-twitch']), $usersInfosAfter['link_twitch']);
-            static::assertSame(\trim($params['form-edit_socials-input-unreal']), $usersInfosAfter['link_unreal']);
+            static::assertSame(Helper::trim($params['form-edit_socials-input-facebook']), $usersInfosAfter['link_facebook']);
+            static::assertSame(Helper::trim($params['form-edit_socials-input-twitter']), $usersInfosAfter['link_twitter']);
+            static::assertSame(Helper::trim($params['form-edit_socials-input-github']), $usersInfosAfter['link_github']);
+            static::assertSame(Helper::trim($params['form-edit_socials-input-youtube']), $usersInfosAfter['link_youtube']);
+            static::assertSame(Helper::trim($params['form-edit_socials-input-twitch']), $usersInfosAfter['link_twitch']);
+            static::assertSame(Helper::trim($params['form-edit_socials-input-unreal']), $usersInfosAfter['link_unreal']);
         } else {
             static::assertSame($usersInfosBefore, $usersInfosAfter);
         }
@@ -1085,32 +1086,32 @@ class ProfileEditPOSTEditSocialsTest extends TestCase
             $labelError = $fieldsLabelError[$field] ?? '';
 
             if ($field === 'facebook') {
-                $value = $hasValue ? \trim($params['form-edit_socials-input-facebook']) : '';
+                $value = $hasValue ? Helper::trim($params['form-edit_socials-input-facebook']) : '';
                 $this->doTestHtmlForm($response, '#form-edit_socials', $this->getHTMLFieldFacebook($value, $hasError, $labelError));
             }
 
             if ($field === 'twitter') {
-                $value = $hasValue ? \trim($params['form-edit_socials-input-twitter']) : '';
+                $value = $hasValue ? Helper::trim($params['form-edit_socials-input-twitter']) : '';
                 $this->doTestHtmlForm($response, '#form-edit_socials', $this->getHTMLFieldTwitter($value, $hasError, $labelError));
             }
 
             if ($field === 'github') {
-                $value = $hasValue ? \trim($params['form-edit_socials-input-github']) : '';
+                $value = $hasValue ? Helper::trim($params['form-edit_socials-input-github']) : '';
                 $this->doTestHtmlForm($response, '#form-edit_socials', $this->getHTMLFieldGithub($value, $hasError, $labelError));
             }
 
             if ($field === 'youtube') {
-                $value = $hasValue ? \trim($params['form-edit_socials-input-youtube']) : '';
+                $value = $hasValue ? Helper::trim($params['form-edit_socials-input-youtube']) : '';
                 $this->doTestHtmlForm($response, '#form-edit_socials', $this->getHTMLFieldYoutube($value, $hasError, $labelError));
             }
 
             if ($field === 'twitch') {
-                $value = $hasValue ? \trim($params['form-edit_socials-input-twitch']) : '';
+                $value = $hasValue ? Helper::trim($params['form-edit_socials-input-twitch']) : '';
                 $this->doTestHtmlForm($response, '#form-edit_socials', $this->getHTMLFieldTwitch($value, $hasError, $labelError));
             }
 
             if ($field === 'unreal') {
-                $value = $hasValue ? \trim($params['form-edit_socials-input-unreal']) : '';
+                $value = $hasValue ? Helper::trim($params['form-edit_socials-input-unreal']) : '';
                 $this->doTestHtmlForm($response, '#form-edit_socials', $this->getHTMLFieldUnreal($value, $hasError, $labelError));
             }
         }

--- a/tests/www/Register/RegisterTest.php
+++ b/tests/www/Register/RegisterTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace tests\www\Register;
 
+use app\helpers\Helper;
 use PHPUnit\Framework\TestCase;
 use Rancoud\Application\ApplicationException;
 use Rancoud\Crypt\Crypt;
@@ -1061,12 +1062,12 @@ class RegisterTest extends TestCase
             $labelError = $fieldsLabelError[$field] ?? '';
 
             if ($field === 'username') {
-                $value = $hasValue ? \trim($params['form-register-input-username']) : '';
+                $value = $hasValue ? Helper::trim($params['form-register-input-username']) : '';
                 $this->doTestHtmlForm($response, '#popin-register', $this->getHTMLFieldUsername($value, $hasError, $labelError));
             }
 
             if ($field === 'email') {
-                $value = $hasValue ? \trim($params['form-register-input-email']) : '';
+                $value = $hasValue ? Helper::trim($params['form-register-input-email']) : '';
                 $this->doTestHtmlForm($response, '#popin-register', $this->getHTMLFieldEmail($value, $hasError, $labelError));
             }
 


### PR DESCRIPTION
# Description
Add `PHP 8.4` to the workflow.
Turn off rule `mb_str_functions` due to `PHP 8.4`.
Add `Helper::trim` to use trim or mb_trim when possible.
Replace `\trim` with `Helper::trim`.