### PR TITLE
fix: update the way to compare and create tags for blueprints

### DIFF
--- a/app/models/TagModel.php
+++ b/app/models/TagModel.php
@@ -110,13 +110,13 @@ class TagModel extends Model
      *
      * @return array|null
      */
-    public function findTagsWithNames(array $tagsToSeek): ?array
+    public function findTagsWithSlugs(array $tagsToSeek): ?array
     {
         $sqlParts = [];
         $params = [];
         $i = 0;
         foreach ($tagsToSeek as $tagToSeek) {
-            $sqlParts[] = 'name = :tag_' . $i;
+            $sqlParts[] = 'slug = :tag_' . $i;
             $params['tag_' . $i] = $tagToSeek;
             ++$i;
         }

--- a/tests/www/IntegrationTest/Service/Tag/TagsTextareaTest.php
+++ b/tests/www/IntegrationTest/Service/Tag/TagsTextareaTest.php
@@ -106,7 +106,7 @@ class TagsTextareaTest extends TestCase
     public static function dataCasesCaseSensitiveTags(): array
     {
         return [
-            '4 tags in textarea - 3 tag before - no creation' => [
+            '4 tags in textarea - 4 tags before - no creation' => [
                 'tagsSQLBefore' => "INSERT INTO tags (`id`, `name`, `slug`) VALUES (1, 'Camera', 'camera'), (2, 'Line Trace', 'line-trace'), (3, 'Test-Debug', 'test-debug'), (4, 'WASD', 'wasd')",
                 'textarea'      => <<<TEXTAREA
                                      camera
@@ -117,7 +117,7 @@ class TagsTextareaTest extends TestCase
                 'tagsIDs'   => '1,2,3,4',
                 'tagsAfter' => [['id' => '1', 'name' => 'Camera', 'slug' => 'camera'], ['id' => '2', 'name' => 'Line Trace', 'slug' => 'line-trace'], ['id' => '3', 'name' => 'Test-Debug', 'slug' => 'test-debug'], ['id' => '4', 'name' => 'WASD', 'slug' => 'wasd']],
             ],
-            '4 tags in textarea - 0 tag before - 2 creation' => [
+            '4 tags in textarea (2 duplicate) - 0 tag before - 2 creation' => [
                 'tagsSQLBefore' => null,
                 'textarea'      => <<<TEXTAREA
                                      4.19

--- a/tests/www/IntegrationTest/Service/Tag/TagsTextareaTest.php
+++ b/tests/www/IntegrationTest/Service/Tag/TagsTextareaTest.php
@@ -103,10 +103,39 @@ class TagsTextareaTest extends TestCase
         ];
     }
 
+    public static function dataCasesCaseSensitiveTags(): array
+    {
+        return [
+            '4 tags in textarea - 3 tag before - no creation' => [
+                'tagsSQLBefore' => "INSERT INTO tags (`id`, `name`, `slug`) VALUES (1, 'Camera', 'camera'), (2, 'Line Trace', 'line-trace'), (3, 'Test-Debug', 'test-debug'), (4, 'WASD', 'wasd')",
+                'textarea'      => <<<TEXTAREA
+                                     camera
+                                     line-trace
+                                     test debug
+                                     WASD
+                                     TEXTAREA,
+                'tagsIDs'   => '1,2,3,4',
+                'tagsAfter' => [['id' => '1', 'name' => 'Camera', 'slug' => 'camera'], ['id' => '2', 'name' => 'Line Trace', 'slug' => 'line-trace'], ['id' => '3', 'name' => 'Test-Debug', 'slug' => 'test-debug'], ['id' => '4', 'name' => 'WASD', 'slug' => 'wasd']],
+            ],
+            '4 tags in textarea - 0 tag before - 2 creation' => [
+                'tagsSQLBefore' => null,
+                'textarea'      => <<<TEXTAREA
+                                     4.19
+                                     4-19
+                                     Third Person Movement
+                                     third-person-movement
+                                     TEXTAREA,
+                'tagsIDs'   => '1,2',
+                'tagsAfter' => [['id' => '1', 'name' => '4.19', 'slug' => '4-19'], ['id' => '2', 'name' => 'third person movement', 'slug' => 'third-person-movement']],
+            ]
+        ];
+    }
+
     /**
      * @dataProvider dataCasesEmptyTextarea
      * @dataProvider dataCasesOneTagInTextarea
      * @dataProvider dataCasesTwoTagsInTextarea
+     * @dataProvider dataCasesCaseSensitiveTags
      *
      * @param string|null $tagsSQLBefore
      * @param string      $textarea
@@ -122,6 +151,7 @@ class TagsTextareaTest extends TestCase
     #[DataProvider('dataCasesEmptyTextarea')]
     #[DataProvider('dataCasesOneTagInTextarea')]
     #[DataProvider('dataCasesTwoTagsInTextarea')]
+    #[DataProvider('dataCasesCaseSensitiveTags')]
     public function testCreate(?string $tagsSQLBefore, string $textarea, ?string $tagsIDs, array $tagsAfter): void
     {
         static::setDatabase();


### PR DESCRIPTION
# Description
Tag's list compared the display name against the database and then create a slug to generate a new tag if not find in the list.
But there was 2 issues:
* When the word "Camera" is compared against "amera" it did not found due to case sensitivity of `in_array` function
* When the word "Line Trace" is compared to "Line-Trace" it will decide to create a new tag but the slug "line-trace" already exist, so there is no tag added.

The fix consist to use only the slugify version to do the comparaison.

fix [#40](https://github.com/blueprintue/feedback/issues/40)