### PR TITLE
feat: invalid sessions after password change and reset (CWE-613)

### DIFF
--- a/app/controllers/www/ProfileEditController.php
+++ b/app/controllers/www/ProfileEditController.php
@@ -584,6 +584,10 @@ class ProfileEditController implements MiddlewareInterface
 
         UserService::updatePassword($this->userID, $params['new_password']);
 
+        Session::deleteUserSessionsInDatabase($this->userID);
+
+        (new LoginMiddleware())->login($this->userID);
+
         Session::setFlash('success-form-change_password', 'Your new password has been saved');
         Session::keepFlash(['success-form-change_password']);
 

--- a/app/controllers/www/ResetPasswordController.php
+++ b/app/controllers/www/ResetPasswordController.php
@@ -176,6 +176,8 @@ class ResetPasswordController implements MiddlewareInterface
 
         try {
             UserService::resetPassword($userID, $params['password']);
+
+            Session::deleteUserSessionsInDatabase($userID);
             // @codeCoverageIgnoreStart
         } catch (\Exception) {
             /*

--- a/tests/www/ForgotPassword/ResetPasswordTest.php
+++ b/tests/www/ForgotPassword/ResetPasswordTest.php
@@ -40,6 +40,7 @@ class ResetPasswordTest extends TestCase
     {
         static::$db->truncateTables('users');
         static::$db->truncateTables('users_infos');
+        static::$db->truncateTables('sessions');
 
         // user generation
         $sql = <<<'SQL'
@@ -73,6 +74,18 @@ class ResetPasswordTest extends TestCase
             'password_reset' => '123'
         ];
         static::$db->insert($sql, $userParams);
+
+        // user sessions
+        $sql = <<<'SQL'
+            INSERT INTO `sessions` (`id`, `id_user`, `last_access`, `content`) VALUES
+                ('session_id_1', 40, UTC_TIMESTAMP(), 'foo'),
+                ('session_id_2', 30, UTC_TIMESTAMP(), 'foo'),
+                ('session_id_3', 40, UTC_TIMESTAMP(), 'foo'),
+                ('session_id_4', 30, UTC_TIMESTAMP(), 'foo'),
+                ('session_id_5', 40, UTC_TIMESTAMP(), 'foo');
+        SQL;
+
+        static::$db->insert($sql);
     }
 
     protected function tearDown(): void
@@ -852,6 +865,10 @@ HTML);
                 static::assertNotSame($userDBBefore, $userDBAfter);
                 static::assertNull($userDBAfter['password_reset']);
                 static::assertNull($userDBAfter['password_reset_at']);
+                static::assertSame(0, static::$db->count('SELECT COUNT(id) FROM sessions WHERE id_user = 30'));
+                static::assertSame(0, static::$db->count("SELECT COUNT(id) FROM sessions WHERE id_user = 30 AND content = 'foo'"));
+                static::assertSame(3, static::$db->count('SELECT COUNT(id) FROM sessions WHERE id_user = 40'));
+                static::assertSame(3, static::$db->count("SELECT COUNT(id) FROM sessions WHERE id_user = 40 AND content = 'foo'"));
             } else {
                 static::assertSame($userDBBefore, $userDBAfter);
             }

--- a/tests/www/Profile/Edit/ProfileEditPOSTChangePasswordTest.php
+++ b/tests/www/Profile/Edit/ProfileEditPOSTChangePasswordTest.php
@@ -71,6 +71,20 @@ class ProfileEditPOSTChangePasswordTest extends TestCase
         static::$db->insert($sql, $userParams);
 
         static::$db->insert("replace into users (id, username, password, slug, email, created_at) values (2, 'anonymous', null, 'anonymous', 'anonymous@mail', utc_timestamp())");
+
+        // user sessions
+        $sql = <<<'SQL'
+            REPLACE INTO `sessions` (`id`, `id_user`, `last_access`, `content`) VALUES
+                ('session_id_1', 189, UTC_TIMESTAMP(), 'foo'),
+                ('session_id_2', 199, UTC_TIMESTAMP(), 'foo'),
+                ('session_id_3', 189, UTC_TIMESTAMP(), 'foo'),
+                ('session_id_4', 195, UTC_TIMESTAMP(), 'foo'),
+                ('session_id_5', 195, UTC_TIMESTAMP(), 'foo'),
+                ('session_id_6', 199, UTC_TIMESTAMP(), 'foo'),
+                ('session_id_7', 189, UTC_TIMESTAMP(), 'foo');
+        SQL;
+
+        static::$db->insert($sql);
     }
 
     protected function tearDown(): void
@@ -85,6 +99,16 @@ class ProfileEditPOSTChangePasswordTest extends TestCase
         yield 'edit OK' => [
             'sqlQueries' => [
                 "UPDATE users SET password = '" . Crypt::hash('password_user_189') . "' WHERE id = 189",
+                <<<'SQL'
+                REPLACE INTO `sessions` (`id`, `id_user`, `last_access`, `content`) VALUES
+                    ('session_id_1', 189, UTC_TIMESTAMP(), 'foo'),
+                    ('session_id_2', 199, UTC_TIMESTAMP(), 'foo'),
+                    ('session_id_3', 189, UTC_TIMESTAMP(), 'foo'),
+                    ('session_id_4', 195, UTC_TIMESTAMP(), 'foo'),
+                    ('session_id_5', 195, UTC_TIMESTAMP(), 'foo'),
+                    ('session_id_6', 199, UTC_TIMESTAMP(), 'foo'),
+                    ('session_id_7', 189, UTC_TIMESTAMP(), 'foo');
+                SQL
             ],
             'userID'     => 189,
             'params'     => [
@@ -114,6 +138,16 @@ class ProfileEditPOSTChangePasswordTest extends TestCase
         yield 'edit OK - xss' => [
             'sqlQueries' => [
                 "UPDATE users SET password = '" . Crypt::hash('password_user_189') . "' WHERE id = 189",
+                <<<'SQL'
+                REPLACE INTO `sessions` (`id`, `id_user`, `last_access`, `content`) VALUES
+                    ('session_id_1', 189, UTC_TIMESTAMP(), 'foo'),
+                    ('session_id_2', 199, UTC_TIMESTAMP(), 'foo'),
+                    ('session_id_3', 189, UTC_TIMESTAMP(), 'foo'),
+                    ('session_id_4', 195, UTC_TIMESTAMP(), 'foo'),
+                    ('session_id_5', 195, UTC_TIMESTAMP(), 'foo'),
+                    ('session_id_6', 199, UTC_TIMESTAMP(), 'foo'),
+                    ('session_id_7', 189, UTC_TIMESTAMP(), 'foo');
+                SQL
             ],
             'userID'     => 189,
             'params'     => [
@@ -776,6 +810,12 @@ class ProfileEditPOSTChangePasswordTest extends TestCase
         if ($isFormSuccess) {
             static::assertNotSame($userBefore, $userAfter);
             static::assertTrue(Crypt::verify($params['form-change_password-input-new_password'], $userAfter['password']));
+            static::assertSame(1, static::$db->count('SELECT COUNT(id) FROM sessions WHERE id_user = 189'));
+            static::assertSame(0, static::$db->count("SELECT COUNT(id) FROM sessions WHERE id_user = 189 AND content = 'foo'"));
+            static::assertSame(2, static::$db->count('SELECT COUNT(id) FROM sessions WHERE id_user = 195'));
+            static::assertSame(2, static::$db->count("SELECT COUNT(id) FROM sessions WHERE id_user = 195 AND content = 'foo'"));
+            static::assertSame(2, static::$db->count('SELECT COUNT(id) FROM sessions WHERE id_user = 199'));
+            static::assertSame(2, static::$db->count("SELECT COUNT(id) FROM sessions WHERE id_user = 199 AND content = 'foo'"));
         } else {
             static::assertSame($userBefore, $userAfter);
         }


### PR DESCRIPTION
# Description
* remove all current user sessions and relogin current user when change password
* remove all user sessions attached to a password reset when it succed to change