### PR TITLE
fix: crons endpoints only localhost in nginx configuration

### DIFF
--- a/rootfs/tpls/etc/nginx/nginx.conf
+++ b/rootfs/tpls/etc/nginx/nginx.conf
@@ -125,5 +125,10 @@ http {
         add_header Cache-Control "max-age=31536000";
         access_log off;
     }
+
+    location /cron/ {
+        allow 127.0.0.1;
+        deny all;
+    }
   }
 }


### PR DESCRIPTION
# Description
Crons endpoints only for localhost